### PR TITLE
Fix default value of includeVariables parameter in tasklist api client

### DIFF
--- a/src/tasklist/lib/TasklistApiClient.ts
+++ b/src/tasklist/lib/TasklistApiClient.ts
@@ -212,7 +212,7 @@ export class TasklistApiClient {
 			.post(`tasks/${taskId}/variables/search`, {
 				body: losslessStringify({
 					variableNames: variableNames || [],
-					includeVariables: includeVariables || {},
+					includeVariables: includeVariables || [],
 				}),
 				headers,
 			})


### PR DESCRIPTION
Hello,

I am getting 500 error without specifying optional `includeVariables`, so I have to workaround it like so:

```js
const taskVariables = await tasklist.getVariables({
  taskId,
  includeVariables: []
});
```

But anyway, here's the fix for that problem.