### PR TITLE
Revert "Fix: The deadline passed to 'waitForReady' in "GrpcClient", was a millisecond gap, but the method needs a date or a TS of the deadline"

### DIFF
--- a/src/zeebe/lib/GrpcClient.ts
+++ b/src/zeebe/lib/GrpcClient.ts
@@ -276,7 +276,7 @@ export class GrpcClient extends EventEmitter {
 		})
 		this.listNameMethods = []
 
-		this.client.waitForReady(new Date(Date.now() + 10000), (error) =>
+		this.client.waitForReady(10000, (error) =>
 			error
 				? this.emit(MiddlewareSignals.Event.Error, error)
 				: this.emit(MiddlewareSignals.Event.Ready)


### PR DESCRIPTION
Reverts camunda/camunda-8-js-sdk#148