### PR TITLE
Add support for oAuth mTLS client authorization

### DIFF
--- a/src/oauth/lib/OAuthProvider.ts
+++ b/src/oauth/lib/OAuthProvider.ts
@@ -30,6 +30,8 @@ export class OAuthProvider implements IOAuthProvider {
 	private static readonly defaultTokenCache = `${homedir}/.camunda`
 	private cacheDir: string
 	private authServerUrl: string
+	private mTLSPrivateKey: string | undefined
+	private mTLSCertChain: string | undefined
 	private clientId: string | undefined
 	private clientSecret: string | undefined
 	private useFileCache: boolean
@@ -61,6 +63,12 @@ export class OAuthProvider implements IOAuthProvider {
 
 		this.clientId = config.ZEEBE_CLIENT_ID
 		this.clientSecret = config.ZEEBE_CLIENT_SECRET
+		this.mTLSPrivateKey = config.CAMUNDA_CUSTOM_PRIVATE_KEY_PATH
+			? fs.readFileSync(config.CAMUNDA_CUSTOM_PRIVATE_KEY_PATH).toString()
+			: undefined
+		this.mTLSCertChain = config.CAMUNDA_CUSTOM_CERT_CHAIN_PATH
+			? fs.readFileSync(config.CAMUNDA_CUSTOM_CERT_CHAIN_PATH).toString()
+			: undefined
 
 		this.consoleClientId = config.CAMUNDA_CONSOLE_CLIENT_ID
 		this.consoleClientSecret = config.CAMUNDA_CONSOLE_CLIENT_SECRET
@@ -284,6 +292,8 @@ export class OAuthProvider implements IOAuthProvider {
 				'user-agent': this.userAgentString,
 				accept: '*/*',
 			},
+			key: this.mTLSPrivateKey,
+			cert: this.mTLSCertChain,
 		}
 
 		trace(`Making token request to the token endpoint: `)


### PR DESCRIPTION
Hi team,

first of all a big thanks for this sdk! We plan to use it at Mercedes-Benz to connect zeebe workers to our self-managed camunda instance.

In our setup, were we have to put both the oAuth server (keycloak) and the zeebe gateway behind an ingress which requires **mTLS client authorization**. As I've tested, client authorization has already been supported for grpc connections, but the OAuthProvider did not support it yet when it requests a token.

So I've added code that uses the same config parameters `CAMUNDA_CUSTOM_CERT_CHAIN_PATH` and `CAMUNDA_CUSTOM_PRIVATE_KEY_PATH` to configure got, but only in case they're set. If they're not set, `key`and `cert`params from got remain `undefined`, and everything works normal.