### PR TITLE
fix: specify the correct audience when getting an Optimize auth token

### DIFF
--- a/src/optimize/lib/OptimizeApiClient.ts
+++ b/src/optimize/lib/OptimizeApiClient.ts
@@ -95,7 +95,7 @@ export class OptimizeApiClient {
 	}
 
 	private async getHeaders(auth = true) {
-		const token = await this.oAuthProvider.getToken('OPERATE')
+		const token = await this.oAuthProvider.getToken('OPTIMIZE')
 
 		const authHeader: { authorization: string } | Record<string, never> = auth
 			? {


### PR DESCRIPTION
Originally reported by @SamanthaHolstine in Camunda internal Slack.

This PR corrects the audience argument for getting an auth token from the OptimizeApiClient. 

The OptimizeApiClient was passing the `OPERATE` audience, instead of `OPTIMIZE`. This was resulting in any request to an authorized Optimize endpoint failing, with a `401 Unauthorized` response.

I confirmed with a local reproduction that changing to `OPTIMIZE` fixes the issue. I didn't find an existing place to put a test; let me know if I overlooked something, or if you have suggestions on how I can include a test for this behavior.

Note also that I made this commit with the `--no-verify` flag, because I could not get unit tests passing locally, seemingly unrelated to my change. See below for the tests that consistently failed for me, maybe you have some suggestions about what I'm missing for those tests to pass.


---

```
 FAIL  src/__tests__/oauth/OAuthProvider.unit.spec.ts (22.853 s)
  ● Console

    console.log
      audience=token&client_id=clientId6&client_secret=clientSecret&grant_type=client_credentials

      at IncomingMessage.<anonymous> (src/__tests__/oauth/OAuthProvider.unit.spec.ts:225:15)

    console.log
      audience=token&client_id=clientId6&client_secret=clientSecret&grant_type=client_credentials

      at IncomingMessage.<anonymous> (src/__tests__/oauth/OAuthProvider.unit.spec.ts:225:15)

    console.log
      Server running on port 3033

      at Server.<anonymous> (src/__tests__/oauth/OAuthProvider.unit.spec.ts:597:12)

  ● OAuthProvider › Uses form encoding for request

    thrown: "Exceeded timeout of 10000 ms for a test while waiting for `done()` to be called.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      249 |     })
      250 |
    > 251 |     it('Uses form encoding for request', (done) => {
          |     ^
      252 |             const serverPort3001 = 3001
      253 |             const o = new OAuthProvider({
      254 |                     config: {

      at src/__tests__/oauth/OAuthProvider.unit.spec.ts:251:2
      at Object.<anonymous> (src/__tests__/oauth/OAuthProvider.unit.spec.ts:37:1)

  ● OAuthProvider › Uses a custom audience for an Operate token, if one is configured

    thrown: "Exceeded timeout of 10000 ms for a test while waiting for `done()` to be called.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      286 |     })
      287 |
    > 288 |     it('Uses a custom audience for an Operate token, if one is configured', (done) => {
          |     ^
      289 |             const serverPort3003 = 3003
      290 |             const o = new OAuthProvider({
      291 |                     config: {

      at src/__tests__/oauth/OAuthProvider.unit.spec.ts:288:2
      at Object.<anonymous> (src/__tests__/oauth/OAuthProvider.unit.spec.ts:37:1)
```

```
 FAIL  src/__tests__/zeebe/ZeebeGrpcClient-unmocked.unit.spec.ts (13.386 s)
  ● ZeebeGrpcClient constructor throws an exception when there is no broker and retry is false

    thrown: "Exceeded timeout of 13000 ms for a test.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      18 | jest.setTimeout(13000)
      19 |
    > 20 | test('ZeebeGrpcClient constructor throws an exception when there is no broker and retry is false', async () => {
         | ^
      21 |      const zbc = new ZeebeGrpcClient({
      22 |              config: {
      23 |                      CAMUNDA_OAUTH_DISABLED: true,

      at Object.<anonymous> (src/__tests__/zeebe/ZeebeGrpcClient-unmocked.unit.spec.ts:20:1)

  ● ZeebeGrpcClient constructor throws an exception when there is no broker and retry is false

    expect.assertions(1)

    Expected one assertion to be called but received zero assertion calls.

      28 |              },
      29 |      })
    > 30 |      expect.assertions(1)
         |             ^
      31 |      try {
      32 |              await zbc.deployResource({
      33 |                      processFilename: './src/__tests__/testdata/hello-world.bpmn',

      at Object.<anonymous> (src/__tests__/zeebe/ZeebeGrpcClient-unmocked.unit.spec.ts:30:9)

```