### PR TITLE
fix(lossless-parser): correctly handle null in objects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
 		"modeler",
 		"operate",
 		"camunda8",
-		"optimize"
+		"optimize",
+		"lossless-parser"
 	],
 	"editor.formatOnSave": true,
 

--- a/src/__tests__/lib/LosslessJsonParser.unit.spec.ts
+++ b/src/__tests__/lib/LosslessJsonParser.unit.spec.ts
@@ -330,3 +330,17 @@ test('LosslessStringify correctly handles nested Dtos', () => {
 		`{"total":3,"decisionsOutputs":[{"someInt32Field":123,"someInt64Field":123}]}`
 	)
 })
+
+test('LosslessJsonParser correctly handles null objects', () => {
+	const json = `{"abc": [null, null, null] }`
+
+	const parsedDto = losslessParse(json)
+	expect(parsedDto.abc).toMatchObject([null, null, null]) // 3 (string)
+})
+
+test('LosslessStringify correctly handles null objects', () => {
+	const json = { abc: [null, null, null] }
+
+	const stringifiedDto = losslessStringify(json)
+	expect(stringifiedDto).toBe(`{"abc":[null,null,null]}`) // 3 (string)
+})

--- a/src/lib/LosslessJsonParser.ts
+++ b/src/lib/LosslessJsonParser.ts
@@ -220,7 +220,10 @@ function parseArrayWithAnnotations<T>(
  * Convert all `LosslessNumber` instances to a number or throw if any are unsafe
  */
 function convertLosslessNumbersToNumberOrThrow<T>(obj: any): T {
-	debug(`Parsing LosslessNumbers to numbers for ${obj.constructor.name}`)
+	debug(`Parsing LosslessNumbers to numbers for ${obj?.constructor?.name}`)
+	if (!obj) {
+		return obj
+	}
 	let currentKey = ''
 	try {
 		Object.keys(obj).forEach((key) => {


### PR DESCRIPTION
the lossless parser now correctly handles null fields in objects

fixes #212