### PR TITLE
chore(repo): fix license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"access": "public"
 	},
 	"author": "josh.wulf@camunda.com",
-	"license": "Apache 2.0",
+	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/camunda/camunda-8-js-sdk.git"


### PR DESCRIPTION
the license field is now Apache-2.0 allowing for correct parsing by tools