### PR TITLE
fix(zeebe): fail job if variables cannot be parsed

### DIFF
--- a/src/zeebe/lib/stringifyVariables.ts
+++ b/src/zeebe/lib/stringifyVariables.ts
@@ -17,17 +17,27 @@ export function parseVariablesAndCustomHeadersToJSON<Variables, CustomHeaders>(
 	inputVariableDto: new (...args: any[]) => Readonly<Variables>,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	customHeadersDto: new (...args: any[]) => Readonly<CustomHeaders>
-): Job<Variables, CustomHeaders> {
-	return Object.assign({}, response, {
-		customHeaders: losslessParse(
-			response.customHeaders,
-			customHeadersDto
-		) as CustomHeaders,
-		variables: losslessParse(
-			response.variables,
-			inputVariableDto
-		) as Readonly<Variables>,
-	}) as Job<Variables, CustomHeaders>
+): Promise<Job<Variables, CustomHeaders>> {
+	return new Promise((resolve, reject) => {
+		try {
+			resolve(
+				Object.assign({}, response, {
+					customHeaders: losslessParse(
+						response.customHeaders,
+						customHeadersDto
+					) as CustomHeaders,
+					variables: losslessParse(
+						response.variables,
+						inputVariableDto
+					) as Readonly<Variables>,
+				}) as Job<Variables, CustomHeaders>
+			)
+		} catch (e) {
+			console.error(`Error parsing variables ${e}`)
+			console.error('Job', response)
+			reject(e)
+		}
+	})
 }
 
 export function stringifyVariables<


### PR DESCRIPTION
if the variable payload cannot be parsed, fail the job rather than throwing an error

fixes #236

## Description of the change

[Describe your changes here]

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
