### PR TITLE
fix(operate): use post request for decision definitions and decision instances endpoints

### DIFF
--- a/src/operate/lib/OperateApiClient.ts
+++ b/src/operate/lib/OperateApiClient.ts
@@ -231,11 +231,13 @@ export class OperateApiClient {
 		const json = this.addTenantIdToFilter(query)
 		const rest = await this.rest
 
-		return rest('decision-definitions/search', {
-			headers,
-			parseJson: (text) => parseSearchResults(text, DecisionDefinition),
-			json,
-		}).json()
+		return rest
+			.post('decision-definitions/search', {
+				headers,
+				parseJson: (text) => parseSearchResults(text, DecisionDefinition),
+				json,
+			})
+			.json()
 	}
 
 	/**
@@ -263,11 +265,13 @@ export class OperateApiClient {
 		const json = this.addTenantIdToFilter(query)
 		const rest = await this.rest
 
-		return rest('decision-instances/search', {
-			headers,
-			parseJson: (text) => parseSearchResults(text, DecisionInstance),
-			json,
-		}).json()
+		return rest
+			.post('decision-instances/search', {
+				headers,
+				parseJson: (text) => parseSearchResults(text, DecisionInstance),
+				json,
+			})
+			.json()
 	}
 
 	/**

--- a/src/operate/lib/OperateDto.ts
+++ b/src/operate/lib/OperateDto.ts
@@ -40,7 +40,8 @@ export class DecisionInstance extends LosslessDto {
 	evaluationFailure!: string
 	@Int64String
 	processDefinitionKey!: string
-	processInstanceKey!: number
+	@Int64String
+	processInstanceKey!: string
 	decisionId!: string
 	decisionDefinitionId!: string
 	decisionName!: string

--- a/src/operate/lib/OperateDto.ts
+++ b/src/operate/lib/OperateDto.ts
@@ -40,6 +40,7 @@ export class DecisionInstance extends LosslessDto {
 	evaluationFailure!: string
 	@Int64String
 	processDefinitionKey!: string
+	processInstanceKey!: number
 	decisionId!: string
 	decisionDefinitionId!: string
 	decisionName!: string


### PR DESCRIPTION
closes #262 

DecisionInstance type should also include processInstanceKey, which is also addressed in this PR

## Description of the change

[Describe your changes here]

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
