### PR TITLE
Fix 351+

### DIFF
--- a/src/zeebe/zb/ZBWorker.ts
+++ b/src/zeebe/zb/ZBWorker.ts
@@ -77,12 +77,19 @@ export class ZBWorker<
 				this.logger.logInfo(`Failing job ${job.key}`)
 				const retries = job.retries - 1
 				try {
-					this.zbClient.failJob({
-						errorMessage: `Unhandled exception in task handler ${e}`,
-						jobKey: job.key,
-						retries,
-						retryBackOff: 0,
-					})
+					this.zbClient
+						.failJob({
+							errorMessage: `Unhandled exception in task handler ${e}`,
+							jobKey: job.key,
+							retries,
+							retryBackOff: 0,
+						})
+						.catch((e) => {
+							console.error(
+								'Any error was thrown while failing the job after an unhandled exception in the task handler'
+							)
+							console.error(e.message)
+						})
 				} catch (e: unknown) {
 					this.logger.logDebug(e)
 				} finally {


### PR DESCRIPTION
## Description of the change

Suppress throw when job cannot be found by `job.complete()` to preserve existing behaviour of SDK. Log exception.

## Type of change

- [ X ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments


