### PR TITLE
fix(zeebe): move polling blocked log message to new verbose level. fixes #356

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The SDK uses the [`debug`](https://github.com/debug-js/debug) library. To enable
 | `camunda:oauth`        | OAuth Token Exchange |
 | `camunda:grpc`         | Zeebe gRPC channel   |
 | `camunda:worker`       | Zeebe Worker         |
+| `camunda:worker:verbose`| Zeebe Worker (additional detail) |
 | `camunda:zeebeclient`  | Zeebe Client         |
 
 Here is an example of turning on debugging for the OAuth and Operate components:

--- a/src/zeebe/lib/ZBWorkerBase.ts
+++ b/src/zeebe/lib/ZBWorkerBase.ts
@@ -26,6 +26,8 @@ import { ZBClientOptions } from './interfaces-published-contract'
 import { parseVariablesAndCustomHeadersToJSON } from '.'
 
 const debug = d('camunda:worker')
+const verbose = d('camunda:worker:verbose')
+
 debug('Loaded ZBWorkerBase')
 
 const MIN_ACTIVE_JOBS_RATIO_BEFORE_ACTIVATING_JOBS = 0.3
@@ -475,7 +477,7 @@ You should call only one job action method in the worker handler. This is a bug 
 			workerIsClosing ||
 			insufficientCapacityAvailable
 		) {
-			debug('Worker polling blocked', {
+			verbose('Worker polling blocked', {
 				pollAlreadyInProgress,
 				workerIsClosing,
 				insufficientCapacityAvailable,


### PR DESCRIPTION
## Description of the change

Change the level of the "polling blocked" message in the Zeebe Worker to verbose (was debug). 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
