### PR TITLE
fix(oauth): pass out full auth header from getToken method

### DIFF
--- a/src/__tests__/oauth/OAuthProvider.unit.spec.ts
+++ b/src/__tests__/oauth/OAuthProvider.unit.spec.ts
@@ -601,11 +601,11 @@ describe('OAuthProvider', () => {
 			CAMUNDA_BASIC_AUTH_USERNAME: 'admin',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		} as any)
-		const token = await oAuthProvider.getToken('ZEEBE')
+		const Authorization = await oAuthProvider.getToken('ZEEBE')
 		await got
 			.get('http://localhost:3033', {
 				headers: {
-					Authorization: 'Basic ' + token,
+					Authorization,
 				},
 			})
 			.then((res) => {
@@ -634,11 +634,11 @@ describe('OAuthProvider', () => {
 			CAMUNDA_OAUTH_TOKEN: 'mysecrettoken',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		} as any)
-		const token = await oAuthProvider.getToken('ZEEBE')
+		const Authorization = await oAuthProvider.getToken('ZEEBE')
 		await got
 			.get('http://localhost:3033', {
 				headers: {
-					Authorization: 'Bearer ' + token,
+					Authorization,
 				},
 			})
 			.then((res) => {

--- a/src/admin/lib/AdminApiClient.ts
+++ b/src/admin/lib/AdminApiClient.ts
@@ -72,7 +72,7 @@ export class AdminApiClient {
 		const token = await this.oAuthProvider.getToken('CONSOLE')
 		const headers = {
 			'content-type': 'application/json',
-			authorization: `Bearer ${token}`,
+			authorization: token,
 			'user-agent': this.userAgentString,
 			accept: '*/*',
 		}

--- a/src/c8/lib/CamundaRestClient.ts
+++ b/src/c8/lib/CamundaRestClient.ts
@@ -149,7 +149,7 @@ export class CamundaRestClient {
 
 		const headers = {
 			'content-type': 'application/json',
-			authorization: `Bearer ${token}`,
+			authorization: token,
 			'user-agent': this.userAgentString,
 			accept: '*/*',
 		}

--- a/src/modeler/lib/ModelerAPIClient.ts
+++ b/src/modeler/lib/ModelerAPIClient.ts
@@ -63,8 +63,7 @@ export class ModelerApiClient {
 	}
 
 	private async getHeaders() {
-		const token = await this.oAuthProvider.getToken('MODELER')
-		const authorization = `Bearer ${token}`
+		const authorization = await this.oAuthProvider.getToken('MODELER')
 		const headers = {
 			'content-type': 'application/json',
 			authorization,

--- a/src/oauth/lib/BasicAuthProvider.ts
+++ b/src/oauth/lib/BasicAuthProvider.ts
@@ -34,6 +34,6 @@ export class BasicAuthProvider implements IOAuthProvider {
 		const token = Buffer.from(`${this.username}:${this.password}`).toString(
 			'base64'
 		)
-		return Promise.resolve(token)
+		return Promise.resolve(`Basic ${token}`)
 	}
 }

--- a/src/oauth/lib/BearerAuthProvider.ts
+++ b/src/oauth/lib/BearerAuthProvider.ts
@@ -29,6 +29,6 @@ export class BearerAuthProvider implements IOAuthProvider {
 	public async getToken(audienceType: TokenGrantAudienceType): Promise<string> {
 		debug(`Token request for ${audienceType}`)
 
-		return Promise.resolve(this.bearerToken)
+		return Promise.resolve(`Bearer ${this.bearerToken}`)
 	}
 }

--- a/src/oauth/lib/OAuthProvider.ts
+++ b/src/oauth/lib/OAuthProvider.ts
@@ -188,7 +188,7 @@ export class OAuthProvider implements IOAuthProvider {
 				trace(`In-memory token ${token.audience} is expired`)
 			} else {
 				trace(`Using in-memory cached token ${token.audience}`)
-				return this.tokenCache[key].access_token
+				return this.addBearer(this.tokenCache[key].access_token)
 			}
 		}
 		if (this.useFileCache) {
@@ -203,7 +203,7 @@ export class OAuthProvider implements IOAuthProvider {
 					trace(`File cached token ${cachedToken.audience} is expired`)
 				} else {
 					trace(`Using file cached token ${cachedToken.audience}`)
-					return cachedToken.access_token
+					return this.addBearer(cachedToken.access_token)
 				}
 			}
 		}
@@ -344,7 +344,7 @@ export class OAuthProvider implements IOAuthProvider {
 						})
 					}
 					this.sendToMemoryCache({ audience: audienceType, token })
-					return token.access_token
+					return this.addBearer(token.access_token)
 				})
 		)
 	}
@@ -474,5 +474,9 @@ export class OAuthProvider implements IOAuthProvider {
 
 	private getAudience(audience: TokenGrantAudienceType) {
 		return this.audienceMap[audience]
+	}
+
+	private addBearer(token: string) {
+		return `Bearer ${token}`
 	}
 }

--- a/src/operate/lib/OperateApiClient.ts
+++ b/src/operate/lib/OperateApiClient.ts
@@ -120,11 +120,11 @@ export class OperateApiClient {
 	}
 
 	private async getHeaders() {
-		const token = await this.oAuthProvider.getToken('OPERATE')
+		const authorization = await this.oAuthProvider.getToken('OPERATE')
 
 		return {
 			'content-type': 'application/json',
-			authorization: `Bearer ${token}`,
+			authorization,
 			'user-agent': this.userAgentString,
 			accept: '*/*',
 		}

--- a/src/optimize/lib/OptimizeApiClient.ts
+++ b/src/optimize/lib/OptimizeApiClient.ts
@@ -96,11 +96,11 @@ export class OptimizeApiClient {
 	}
 
 	private async getHeaders(auth = true) {
-		const token = await this.oAuthProvider.getToken('OPTIMIZE')
+		const authorization = await this.oAuthProvider.getToken('OPTIMIZE')
 
 		const authHeader: { authorization: string } | Record<string, never> = auth
 			? {
-					authorization: `Bearer ${token}`,
+					authorization,
 				}
 			: {}
 

--- a/src/tasklist/lib/TasklistApiClient.ts
+++ b/src/tasklist/lib/TasklistApiClient.ts
@@ -98,10 +98,10 @@ export class TasklistApiClient {
 	}
 
 	private async getHeaders() {
-		const token = await this.oAuthProvider.getToken('TASKLIST')
+		const authorization = await this.oAuthProvider.getToken('TASKLIST')
 		return {
 			'content-type': 'application/json',
-			authorization: `Bearer ${token}`,
+			authorization,
 			'user-agent': this.userAgentString,
 			accept: '*/*',
 		}

--- a/src/zeebe/lib/GrpcClient.ts
+++ b/src/zeebe/lib/GrpcClient.ts
@@ -538,8 +538,8 @@ export class GrpcClient extends EventEmitter {
 		const metadata = new Metadata({ waitForReady: false })
 		metadata.add('user-agent', this.userAgentString)
 		if (this.oAuth) {
-			const token = await this.oAuth.getToken('ZEEBE')
-			metadata.add('Authorization', `Bearer ${token}`)
+			const authorization = await this.oAuth.getToken('ZEEBE')
+			metadata.add('Authorization', authorization)
 		}
 		return metadata
 	}

--- a/src/zeebe/zb/ZeebeRESTClient.ts
+++ b/src/zeebe/zb/ZeebeRESTClient.ts
@@ -87,11 +87,11 @@ export class ZeebeRestClient {
 	}
 
 	private async getHeaders() {
-		const token = await this.oAuthProvider.getToken('ZEEBE')
+		const authorization = await this.oAuthProvider.getToken('ZEEBE')
 
 		const headers = {
 			'content-type': 'application/json',
-			authorization: `Bearer ${token}`,
+			authorization,
 			'user-agent': this.userAgentString,
 			accept: '*/*',
 		}


### PR DESCRIPTION
fixes #367

## Description of the change

Passes out the entire authorization header from the `getToken` method. This allows the correct Basic Auth header to be used. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

