### PR TITLE
fix(operate): allow paging for getVariablesforProcess

### DIFF
--- a/src/__tests__/operate/operate-integration.spec.ts
+++ b/src/__tests__/operate/operate-integration.spec.ts
@@ -61,10 +61,21 @@ test('getJSONVariablesforProcess works', async () => {
 	})
 
 	// Wait for Operate to catch up.
-	await new Promise((res) => setTimeout(() => res(null), 15000))
 	// Make sure that the process instance exists in Operate.
 	// Operate is eventually consistent, so we need to wait a bit.
-	const process = await c.getProcessInstance(p.processInstanceKey)
+	const maxRetries = 15
+	const delay = 1000
+	let process
+
+	for (let i = 0; i < maxRetries; i++) {
+		process = await c.getProcessInstance(p.processInstanceKey).catch(() => null)
+		if (process) break
+		await new Promise((res) => setTimeout(res, delay))
+	}
+	if (!process) {
+		throw new Error('Process instance not found within the timeout period')
+	}
+
 	// If this fails, it is probably a timing issue.
 	expect(process.key).toBe(p.processInstanceKey)
 	const res = await c.getJSONVariablesforProcess(p.processInstanceKey)
@@ -95,11 +106,21 @@ test('getVariablesforProcess paging works', async () => {
 	})
 
 	// Wait for Operate to catch up.
-	await new Promise((res) => setTimeout(() => res(null), 15000))
 	// Make sure that the process instance exists in Operate.
 	// Operate is eventually consistent, so we need to wait a bit.
-	const process = await c.getProcessInstance(p.processInstanceKey)
-	// If this fails, it is probably a timing issue.
+	const maxRetries = 15
+	const delay = 1000
+	let process
+
+	for (let i = 0; i < maxRetries; i++) {
+		process = await c.getProcessInstance(p.processInstanceKey).catch(() => null)
+		if (process) break
+		await new Promise((res) => setTimeout(res, delay))
+	}
+	if (!process) {
+		throw new Error('Process instance not found within the timeout period')
+	}
+
 	expect(process.key).toBe(p.processInstanceKey)
 	const res = await c.getVariablesforProcess(p.processInstanceKey, { size: 5 })
 	expect(res.items[0].name).toBe('foo')

--- a/src/operate/lib/OperateApiClient.ts
+++ b/src/operate/lib/OperateApiClient.ts
@@ -525,19 +525,27 @@ export class OperateApiClient {
 	}
 
 	/**
-	 * @description Retrieve the variables for a Process Instance, given its key
+	 * @description Retrieve the variables for a Process Instance, given its key. Documentation: https://docs.camunda.io/docs/apis-tools/operate-api/specifications/search/
 	 * @throws {RESTError}
 	 * @param processInstanceKey
 	 * @returns
 	 */
 	public async getVariablesforProcess(
-		processInstanceKey: number | string
-	): Promise<{ items: Variable[] }> {
+		processInstanceKey: number | string,
+		options: {
+			size?: number
+			searchAfter?: unknown[]
+			sort?: { field: string; order?: 'ASC' | 'DESC' }[]
+		} = {}
+	): Promise<{ items: Variable[]; sortValues: unknown[]; total: number }> {
 		const headers = await this.getHeaders()
 		const body = {
 			filter: {
 				processInstanceKey,
 			},
+			size: options.size ?? 1000,
+			searchAfter: options.searchAfter,
+			sort: options.sort ?? [{ field: 'name' }],
 		}
 		const rest = await this.rest
 
@@ -555,14 +563,15 @@ export class OperateApiClient {
 	 * @throws {RESTError}
 	 */
 	public async getJSONVariablesforProcess<T extends { [key: string]: JSONDoc }>(
-		processInstanceKey: number | string
+		processInstanceKey: number | string,
+		size = 1000
 	): Promise<T> {
 		const headers = await this.getHeaders()
 		const body = {
 			filter: {
 				processInstanceKey,
 			},
-			size: 1000,
+			size,
 		}
 		const rest = await this.rest
 


### PR DESCRIPTION
fixes #387

## Description of the change

This pull request fixes issue https://github.com/camunda/camunda-8-js-sdk/issues/387 by enabling paging for fetching variables of a process instance via the Operate API client. Key changes include:

Replacing a fixed timeout with a polling loop to wait for a process instance.
Adding a new test to validate the paging mechanism in getVariablesforProcess.
Updating the OperateApiClient to support pagination options.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
