### PR TITLE
Fix job polling when currentlyActiveJobsCount = maxJobsToActivate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.29](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.28...v8.6.29) (2025-03-04)
+
+
+### Bug Fixes
+
+* fix searchUserTasks ([a39ad05](https://github.com/camunda/camunda-8-js-sdk/commit/a39ad05f58c0ae43fb1145ac2716dac996b8d667))
+
 ## [8.6.28](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.27...v8.6.28) (2025-02-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [8.6.26](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.25...v8.6.26) (2025-02-26)
+
+
+### Bug Fixes
+
+* **repo:** close backoff timers on worker close ([405595a](https://github.com/camunda/camunda-8-js-sdk/commit/405595a2d7c9a4ca6687204e83fce3614ccf5599))
+
+
+### Features
+
+* **camunda:** implement backoff on errors for REST job worker ([4895942](https://github.com/camunda/camunda-8-js-sdk/commit/4895942ac8a98caef346997d63d75a48a69a4b2c)), closes [#370](https://github.com/camunda/camunda-8-js-sdk/issues/370)
+
 ## [8.6.25](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.24...v8.6.25) (2025-02-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.24](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.23...v8.6.24) (2025-02-12)
+
+
+### Features
+
+* **zeebe:** support 8.7 string entity keys (backwards-compatible with int64) ([1ea31f0](https://github.com/camunda/camunda-8-js-sdk/commit/1ea31f00bfcda30cc1e683abd75210c62e1c363d)), closes [#279](https://github.com/camunda/camunda-8-js-sdk/issues/279)
+
 ## [8.6.23](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.22...v8.6.23) (2025-02-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.28](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.27...v8.6.28) (2025-02-28)
+
+
+### Bug Fixes
+
+* **camunda8:** remove experimental decorator ([809fe9b](https://github.com/camunda/camunda-8-js-sdk/commit/809fe9b26fb5952188c6f1f88b8d6f376669d917))
+
 ## [8.6.27](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.26...v8.6.27) (2025-02-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.21](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.20...v8.6.21) (2025-01-24)
+
+
+### Bug Fixes
+
+* **zeebe:** move polling blocked log message to new verbose level. fixes [#356](https://github.com/camunda/camunda-8-js-sdk/issues/356) ([62c1459](https://github.com/camunda/camunda-8-js-sdk/commit/62c1459afcca368a6712d75ead4d7c4f1c68dd82))
+
 ## [8.6.20](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.19...v8.6.20) (2025-01-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.23](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.22...v8.6.23) (2025-02-05)
+
+
+### Bug Fixes
+
+* **oauth:** pass out full auth header from getToken method ([55a19b6](https://github.com/camunda/camunda-8-js-sdk/commit/55a19b65e0d2e9bcb6e168139ee1af0f8770d6f9)), closes [#367](https://github.com/camunda/camunda-8-js-sdk/issues/367)
+
 ## [8.6.22](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.21...v8.6.22) (2025-02-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [8.6.30](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.29...v8.6.30) (2025-03-05)
+
+
+### Features
+
+* **camunda8:** support getUserTask (8.8) ([26e0507](https://github.com/camunda/camunda-8-js-sdk/commit/26e0507e6d7b9f79802aa59df2520ffceb9126f9))
+* **camunda:** implement getUserTaskVariables ([6dd59f6](https://github.com/camunda/camunda-8-js-sdk/commit/6dd59f681039802a26344732c9ddbf94a733c91d)), closes [#342](https://github.com/camunda/camunda-8-js-sdk/issues/342)
+* **camunda:** implement searchProcessInstances. fixes [#320](https://github.com/camunda/camunda-8-js-sdk/issues/320) ([bce0eb1](https://github.com/camunda/camunda-8-js-sdk/commit/bce0eb1913764290ffd1427506052687b95b0586))
+
 ## [8.6.29](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.28...v8.6.29) (2025-03-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.18](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.17...v8.6.18) (2024-12-20)
+
+
+### Bug Fixes
+
+* **modeler:** update SaaS URL for Modeler ([563e866](https://github.com/camunda/camunda-8-js-sdk/commit/563e86662f93daadc71fd433fbb4bce26de240c1))
+
 ## [8.6.17](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.16...v8.6.17) (2024-12-19)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.17](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.16...v8.6.17) (2024-12-19)
+
+
+### Bug Fixes
+
+* **zeebe:** update JS GPRC lib dependency, release stream resources on end ([89fd95c](https://github.com/camunda/camunda-8-js-sdk/commit/89fd95c5d1c0a90d37bd18a80ffd62b017f9a8a0))
+
 ## [8.6.16](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.15...v8.6.16) (2024-11-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## [8.6.14](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.13...v8.6.14) (2024-10-24)
+
+
+### Bug Fixes
+
+* **camunda8:** correctly parse autostart parameter of JobWorker ([cb95946](https://github.com/camunda/camunda-8-js-sdk/commit/cb95946ab989f86a5992900292db2227be0824db))
+* **camunda8:** type variables in async process instance start as never ([3055734](https://github.com/camunda/camunda-8-js-sdk/commit/3055734f521341aff850b6545c8919d38d9642a6))
+* **lossless-parser:** correctly parse number array ([d69729a](https://github.com/camunda/camunda-8-js-sdk/commit/d69729ad07f05649a59b9f89282dc01f87698b4f)), closes [#258](https://github.com/camunda/camunda-8-js-sdk/issues/258)
+* **lossless-parser:** throw on encountering Date, Map, or Set ([bb5d8ea](https://github.com/camunda/camunda-8-js-sdk/commit/bb5d8ea666d7d6f0da9823f7ecf0a187708eab6b)), closes [#254](https://github.com/camunda/camunda-8-js-sdk/issues/254)
+* **zeebe:** do not override explicit ZEEBE_GRPC_ADDRESS with default ZEEBE_ADDRESS ([cd6080f](https://github.com/camunda/camunda-8-js-sdk/commit/cd6080fcaa8073e4655f72127af30db11f9ef743)), closes [#245](https://github.com/camunda/camunda-8-js-sdk/issues/245)
+* **zeebe:** throw on client if array passed as variables to CompleteJob ([40a6316](https://github.com/camunda/camunda-8-js-sdk/commit/40a63164a7588ea81fa0df16e9538fa5366dc049)), closes [#247](https://github.com/camunda/camunda-8-js-sdk/issues/247)
+
+
+### Features
+
+* **camunda8:** add C8RestClient ([8e93c92](https://github.com/camunda/camunda-8-js-sdk/commit/8e93c92bfb3684b530428f253f5de05c771e4215)), closes [#235](https://github.com/camunda/camunda-8-js-sdk/issues/235)
+* **camunda8:** add modifyAuthorization method ([0d97f68](https://github.com/camunda/camunda-8-js-sdk/commit/0d97f681ad1a1c9d295f43c83f342b6eb5cfa3da))
+* **camunda8:** complete deployResources feature ([8043ac9](https://github.com/camunda/camunda-8-js-sdk/commit/8043ac9afe5f6f6ec6e8bdfa90dbf40def6a0510))
+* **camunda8:** implement createProcessInstanceWithResult ([4ec4fa1](https://github.com/camunda/camunda-8-js-sdk/commit/4ec4fa1b6c1554bbac04ba275da3e1bba2dbf012))
+* **camunda8:** implement deleteResource over REST ([1dcb101](https://github.com/camunda/camunda-8-js-sdk/commit/1dcb1019b96788d952363d776a6976b99588d541)), closes [#251](https://github.com/camunda/camunda-8-js-sdk/issues/251)
+* **camunda8:** implement deployResources REST API ([debd212](https://github.com/camunda/camunda-8-js-sdk/commit/debd2122e713e98e3180a0bf0b200a1560788b81))
+* **camunda8:** implement publishMessage over REST ([057a9fe](https://github.com/camunda/camunda-8-js-sdk/commit/057a9feaf1a6e13011f130ca201947e39de54390)), closes [#250](https://github.com/camunda/camunda-8-js-sdk/issues/250)
+* **camunda8:** support broadcastSignal over REST ([43f82a4](https://github.com/camunda/camunda-8-js-sdk/commit/43f82a44f69f0217003775d422c741555f1fe6b1)), closes [#248](https://github.com/camunda/camunda-8-js-sdk/issues/248)
+* **camunda8:** support pluggable winston logging for C8RestClient ([d41d3f8](https://github.com/camunda/camunda-8-js-sdk/commit/d41d3f8de6afe2d8d3daff207519a52119f26cc9))
+* **camunda8:** support updateElementInstanceVariables ([7de82b7](https://github.com/camunda/camunda-8-js-sdk/commit/7de82b75c9a08fe34444d549e3c9c2077a768b3e)), closes [#249](https://github.com/camunda/camunda-8-js-sdk/issues/249)
+* **repo:** support passing middleware ([1b7715e](https://github.com/camunda/camunda-8-js-sdk/commit/1b7715e0e2778b058d7e0d8b67f29a27007c06af)), closes [#261](https://github.com/camunda/camunda-8-js-sdk/issues/261)
+* **zeebe:** add operationReference field to gRPC methods ([2e5af66](https://github.com/camunda/camunda-8-js-sdk/commit/2e5af662f9ecc1ee23115eb4232e0633afde3efe)), closes [#237](https://github.com/camunda/camunda-8-js-sdk/issues/237)
+* **zeebe:** create and cancel process instances over REST ([a49d217](https://github.com/camunda/camunda-8-js-sdk/commit/a49d217f95b9b550bedd9af79fe9d950ad31add2))
+* **zeebe:** lossless parse REST variables and customheaders ([f19a252](https://github.com/camunda/camunda-8-js-sdk/commit/f19a2520778836c34a3685d584c4969380672804)), closes [#244](https://github.com/camunda/camunda-8-js-sdk/issues/244)
+
 ## [8.6.13](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.12...v8.6.13) (2024-09-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.31](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.30...v8.6.31) (2025-03-05)
+
+
+### Bug Fixes
+
+* use ZEEBE_TOKEN_AUDIENCE if set ([ac46921](https://github.com/camunda/camunda-8-js-sdk/commit/ac46921f94a5c58fccc39553d9120eb82897b44e)), closes [#392](https://github.com/camunda/camunda-8-js-sdk/issues/392)
+
 ## [8.6.30](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.29...v8.6.30) (2025-03-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.25](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.24...v8.6.25) (2025-02-17)
+
+
+### Bug Fixes
+
+* **zeebe:** throw UNAUTHENTICATED error on ActivateJobs from stream.error event ([d44029e](https://github.com/camunda/camunda-8-js-sdk/commit/d44029e3c181a9c458de91319db4631c67d4bdf7)), closes [#378](https://github.com/camunda/camunda-8-js-sdk/issues/378)
+
 ## [8.6.24](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.23...v8.6.24) (2025-02-12)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.15](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.14...v8.6.15) (2024-10-24)
+
+
+### Bug Fixes
+
+* **modeler:** correct HTTP methods for file methods. fixes [#269](https://github.com/camunda/camunda-8-js-sdk/issues/269) ([7819baa](https://github.com/camunda/camunda-8-js-sdk/commit/7819baa83124a4e0cdf40e33e55803a64a1b6282))
+
 ## [8.6.14](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.13...v8.6.14) (2024-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.6.32](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.31...v8.6.32) (2025-03-06)
+
+
+### Bug Fixes
+
+* add tests and documentation for logging ([3522faf](https://github.com/camunda/camunda-8-js-sdk/commit/3522faf3cfcd0a7e80315ee1f49936ee5cd867f2)), closes [#397](https://github.com/camunda/camunda-8-js-sdk/issues/397)
+* **operate:** allow paging for getVariablesforProcess ([b94532d](https://github.com/camunda/camunda-8-js-sdk/commit/b94532d3480764bc6abda795f85b8d8db382d517)), closes [#387](https://github.com/camunda/camunda-8-js-sdk/issues/387)
+
 ## [8.6.31](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.30...v8.6.31) (2025-03-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [8.6.20](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.19...v8.6.20) (2025-01-23)
+
+
+### Bug Fixes
+
+* **zeebe:** catch exception in fail job on unhandled exception in job handler. fixes [#351](https://github.com/camunda/camunda-8-js-sdk/issues/351) ([91e7213](https://github.com/camunda/camunda-8-js-sdk/commit/91e7213a8530ff8d8a46e2f71186e929b9154bc7))
+* **zeebe:** do not fail jobs that are already not found ([448575c](https://github.com/camunda/camunda-8-js-sdk/commit/448575c6489811869cc88f7e6db7b0e9a7e201ec))
+
 ## [8.6.19](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.18...v8.6.19) (2025-01-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.16](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.15...v8.6.16) (2024-11-15)
+
+
+### Features
+
+* **authorization:** add bearer token authorization ([f7d1ff3](https://github.com/camunda/camunda-8-js-sdk/commit/f7d1ff30e53583a09a1fc49ba258e9af7471b2dc))
+
 ## [8.6.15](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.14...v8.6.15) (2024-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [8.6.27](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.26...v8.6.27) (2025-02-27)
+
+
+### Bug Fixes
+
+* **camunda8:** add optional tenantId to deployResourcesFromFiles ([dff868e](https://github.com/camunda/camunda-8-js-sdk/commit/dff868ea75eeac04c56c26ed3dc6e0e65bf6e201)), closes [#375](https://github.com/camunda/camunda-8-js-sdk/issues/375)
+
+
+### Features
+
+* **camunda8:** add queryVariables method. fixes [#343](https://github.com/camunda/camunda-8-js-sdk/issues/343) ([b361d71](https://github.com/camunda/camunda-8-js-sdk/commit/b361d71028b7d58afa88a3bbea21ef55117ca2a5))
+* **camunda8:** implement findUserTasks ([d2baa70](https://github.com/camunda/camunda-8-js-sdk/commit/d2baa70502516cf1c18daed1253c079fd8a4e271)), closes [#341](https://github.com/camunda/camunda-8-js-sdk/issues/341)
+* **camunda:** implement getUserTask. fixes [#339](https://github.com/camunda/camunda-8-js-sdk/issues/339) ([8bcb59a](https://github.com/camunda/camunda-8-js-sdk/commit/8bcb59affcc4b7ef9b1d4ff9a0f0a1500d3b257a))
+
 ## [8.6.26](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.25...v8.6.26) (2025-02-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.19](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.18...v8.6.19) (2025-01-23)
+
+
+### Bug Fixes
+
+* **zeebe:** propagate 'NOT_FOUND' error on job.complete(). fixes [#351](https://github.com/camunda/camunda-8-js-sdk/issues/351) ([59ebf5d](https://github.com/camunda/camunda-8-js-sdk/commit/59ebf5d91626927619d20e0656b2ed2ec538c0e4))
+
 ## [8.6.18](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.17...v8.6.18) (2024-12-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [8.6.22](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.21...v8.6.22) (2025-02-04)
+
+
+### Features
+
+* **zeebe:** implement backoff on UNAUTHENTICATED error for workers ([56c3c78](https://github.com/camunda/camunda-8-js-sdk/commit/56c3c78429e899aa139c92ac03bcf6d62e5d0850)), closes [#366](https://github.com/camunda/camunda-8-js-sdk/issues/366)
+
 ## [8.6.21](https://github.com/camunda/camunda-8-js-sdk/compare/v8.6.20...v8.6.21) (2025-01-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.21",
+	"version": "8.6.22",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.21",
+			"version": "8.6.22",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.20",
+	"version": "8.6.21",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.20",
+			"version": "8.6.21",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.29",
+	"version": "8.6.30",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.29",
+			"version": "8.6.30",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.14",
+	"version": "8.6.15",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.14",
+			"version": "8.6.15",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.31",
+	"version": "8.6.32",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.31",
+			"version": "8.6.32",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.17",
+	"version": "8.6.18",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.17",
+			"version": "8.6.18",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.30",
+	"version": "8.6.31",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.30",
+			"version": "8.6.31",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.13",
+	"version": "8.6.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.13",
+			"version": "8.6.14",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.23",
+	"version": "8.6.24",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.23",
+			"version": "8.6.24",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.27",
+	"version": "8.6.28",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.27",
+			"version": "8.6.28",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.19",
+	"version": "8.6.20",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.19",
+			"version": "8.6.20",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.24",
+	"version": "8.6.25",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.24",
+			"version": "8.6.25",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.28",
+	"version": "8.6.29",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.28",
+			"version": "8.6.29",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.16",
+	"version": "8.6.17",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.16",
+			"version": "8.6.17",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.26",
+	"version": "8.6.27",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.26",
+			"version": "8.6.27",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.25",
+	"version": "8.6.26",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.25",
+			"version": "8.6.26",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.22",
+	"version": "8.6.23",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.22",
+			"version": "8.6.23",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.15",
+	"version": "8.6.16",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.15",
+			"version": "8.6.16",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.18",
+	"version": "8.6.19",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@camunda8/sdk",
-			"version": "8.6.18",
+			"version": "8.6.19",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "1.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.27",
+	"version": "8.6.28",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.29",
+	"version": "8.6.30",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.30",
+	"version": "8.6.31",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.25",
+	"version": "8.6.26",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.22",
+	"version": "8.6.23",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.18",
+	"version": "8.6.19",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.23",
+	"version": "8.6.24",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.15",
+	"version": "8.6.16",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.28",
+	"version": "8.6.29",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.13",
+	"version": "8.6.14",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.19",
+	"version": "8.6.20",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.21",
+	"version": "8.6.22",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.17",
+	"version": "8.6.18",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.14",
+	"version": "8.6.15",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.20",
+	"version": "8.6.21",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.31",
+	"version": "8.6.32",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.24",
+	"version": "8.6.25",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.16",
+	"version": "8.6.17",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda8/sdk",
-	"version": "8.6.26",
+	"version": "8.6.27",
 	"description": "",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/c8/lib/CamundaJobWorker.ts
+++ b/src/c8/lib/CamundaJobWorker.ts
@@ -165,6 +165,7 @@ export class CamundaJobWorker<
 		this.pollLock = true
 		if (this.currentlyActiveJobCount >= this.config.maxJobsToActivate) {
 			this.log.debug(`At capacity - not requesting more jobs`, this.logMeta())
+			this.pollLock = false
 			return
 		}
 


### PR DESCRIPTION
There is a bug right now when currentlyActiveJobsCount = maxJobsToActivate, the client stops polling for new jobs.

## Description of the change

Fix job polling when currentlyActiveJobsCount = maxJobsToActivate

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
