### PR TITLE
fix: polling when maxJobsToActivate is reached

### DIFF
--- a/src/c8/lib/CamundaJobWorker.ts
+++ b/src/c8/lib/CamundaJobWorker.ts
@@ -165,6 +165,7 @@ export class CamundaJobWorker<
 		this.pollLock = true
 		if (this.currentlyActiveJobCount >= this.config.maxJobsToActivate) {
 			this.log.debug(`At capacity - not requesting more jobs`, this.logMeta())
+			this.pollLock = false
 			return
 		}
 


### PR DESCRIPTION
Fix a bug when currentlyActiveJobsCount = maxJobsToActivate, the client stops polling for new jobs.

## Description of the change

Restart job polling if currentlyActiveJobsCount = maxJobsToActivate

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
