### PR TITLE
Alpha

### DIFF
--- a/src/__tests__/operate/operate-integration.spec.ts
+++ b/src/__tests__/operate/operate-integration.spec.ts
@@ -76,9 +76,11 @@ test('getJSONVariablesforProcess works', async () => {
 		throw new Error('Process instance not found within the timeout period')
 	}
 
-	// If this fails, it is probably a timing issue.
 	expect(process.key).toBe(p.processInstanceKey)
+	// We need to wait further for the variables to be populated in Operate
+	await new Promise((res) => setTimeout(res, 5000))
 	const res = await c.getJSONVariablesforProcess(p.processInstanceKey)
+
 	expect(res.foo).toBe('bar')
 })
 
@@ -122,6 +124,8 @@ test('getVariablesforProcess paging works', async () => {
 	}
 
 	expect(process.key).toBe(p.processInstanceKey)
+	// We need to wait further for the variables to be populated in Operate
+	await new Promise((res) => setTimeout(res, 5000))
 	const res = await c.getVariablesforProcess(p.processInstanceKey, { size: 5 })
 	expect(res.items[0].name).toBe('foo')
 	const nextPage = await c.getVariablesforProcess(p.processInstanceKey, {


### PR DESCRIPTION
## Description of the change

This PR introduces two main changes:

In the integration tests, a fixed delay is added before fetching process variables to ensure they are populated.
In the Camunda job worker, pollLock is explicitly reset when the maximum job capacity is reached.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


