### PR TITLE
refactor(camunda8): deprecate old userTask methods

### DIFF
--- a/src/__tests__/c8/rest/completeUserTask.rest.spec.ts
+++ b/src/__tests__/c8/rest/completeUserTask.rest.spec.ts
@@ -1,0 +1,61 @@
+import path from 'node:path'
+
+import { QueryUserTasksResponse } from 'c8/lib/C8Dto'
+
+import { CamundaRestClient } from '../../../c8/lib/CamundaRestClient'
+
+const c8 = new CamundaRestClient()
+const testProcessId = 'completeUserTask-rest-test-process'
+let processDefinitionId, processDefinitionKey
+
+beforeAll(async () => {
+	const res = await c8.deployResourcesFromFiles([
+		path.join('.', 'src', '__tests__', 'testdata', `${testProcessId}.bpmn`),
+	])
+	;({ processDefinitionId, processDefinitionKey } = res.processes[0])
+})
+
+test('It can complete a user task', async () => {
+	// Start the process but don't await the final result yet
+	const instancePromise = c8.createProcessInstanceWithResult({
+		processDefinitionKey,
+		variables: {},
+	})
+
+	// Give the process a moment to start and create the task
+	// This could be replaced with a more robust polling mechanism
+	await new Promise((resolve) => setTimeout(resolve, 500))
+
+	// Poll until we find a task
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let availableTasks: QueryUserTasksResponse = { page: 1, items: [] } as any
+	const maxAttempts = 20
+	let attempts = 0
+
+	while (availableTasks?.items.length === 0 && attempts < maxAttempts) {
+		attempts++
+		availableTasks = await c8.searchUserTasks({
+			filter: { processDefinitionId },
+		})
+
+		if (availableTasks.items.length === 0) {
+			// Wait 200ms before trying again
+			await new Promise((resolve) => setTimeout(resolve, 200))
+		}
+	}
+
+	if (availableTasks.items.length === 0) {
+		throw new Error('No user tasks became available after polling')
+	}
+
+	console.log('Available tasks:', availableTasks)
+	await c8.completeUserTask({
+		userTaskKey: availableTasks.items[0].userTaskKey,
+	})
+
+	// Now wait for the process to complete
+	const instance = await instancePromise
+
+	// Add assertions here as needed
+	expect(instance).toBeDefined()
+})

--- a/src/__tests__/logging/custom-loggers.ts
+++ b/src/__tests__/logging/custom-loggers.ts
@@ -4,16 +4,17 @@ import Transport from 'winston-transport'
 import { Camunda8 } from '../../c8/index'
 import { createLogger } from '../../c8/lib/C8Logger'
 
-const logger = pino({ level: 'trace' })
-logger.info('Pino console logger created')
-
 // Manually verified - it works
 xtest('It can use pino as a logging library', async () => {
+	const logger = pino({ level: 'trace' })
+	logger.info('Pino console logger created')
+
 	const c8 = new Camunda8({
 		logger,
 	})
 	const rest = c8.getCamundaRestClient()
 	const topology = await rest.getTopology()
+
 	c8.log.info(JSON.stringify(topology))
 })
 

--- a/src/__tests__/testdata/completeUserTask-rest-test-process.bpmn
+++ b/src/__tests__/testdata/completeUserTask-rest-test-process.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0g125lc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="completeUserTask-rest-test-process" name="Test completeUserTask test" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start completeUserTask test">
+      <bpmn:outgoing>Flow_05ioe4x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_05ioe4x" sourceRef="StartEvent_1" targetRef="Activity_1nhbuqp" />
+    <bpmn:endEvent id="Event_0qocrmi" name="End completeUserTask test">
+      <bpmn:incoming>Flow_0mabz42</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0mabz42" sourceRef="Activity_1nhbuqp" targetRef="Event_0qocrmi" />
+    <bpmn:userTask id="Activity_1nhbuqp" name="Test User Task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05ioe4x</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mabz42</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="completeUserTask-rest-test-process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="145" width="85" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0qocrmi_di" bpmnElement="Event_0qocrmi">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="398" y="145" width="85" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18winmy_di" bpmnElement="Activity_1nhbuqp">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_05ioe4x_di" bpmnElement="Flow_05ioe4x">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mabz42_di" bpmnElement="Flow_0mabz42">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -605,6 +605,17 @@ export interface UserTask {
 	formKey?: string
 }
 
+export interface AssignUserTaskRequest {
+	/** The key of the user task to assign. */
+	userTaskKey: string
+	/** The assignee for the user task. The assignee must not be empty or null. */
+	assignee: string
+	/** By default, the task is reassigned if it was already assigned. Set this to false to return an error in such cases. The task must then first be unassigned to be assigned again. Use this when you have users picking from group task queues to prevent race conditions. */
+	allowOverride?: boolean
+	/** A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to "assign". */
+	action: string
+}
+
 /** Sort field criteria. */
 export interface UserTaskVariablesSortRequest {
 	/** The field to sort by. */

--- a/src/c8/lib/CamundaRestClient.ts
+++ b/src/c8/lib/CamundaRestClient.ts
@@ -38,6 +38,7 @@ import {
 } from '../../zeebe/types'
 
 import {
+	AssignUserTaskRequest,
 	BroadcastSignalResponse,
 	CorrelateMessageResponse,
 	CreateProcessInstanceReq,
@@ -80,6 +81,7 @@ const trace = debug('camunda:zeebe-rest')
 const CAMUNDA_REST_API_VERSION = 'v2'
 
 class DefaultLosslessDto extends LosslessDto {}
+
 /**
  * The client for the unified Camunda 8 REST API.
  *
@@ -266,22 +268,30 @@ export class CamundaRestClient {
 	 * Documentation: https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/assign-user-task/
 	 *
 	 * @since 8.6.0
+	 * @deprecated use `assignUserTask`
 	 */
 	public async assignTask({
 		userTaskKey,
 		assignee,
 		allowOverride = true,
 		action = 'assign',
-	}: {
-		/** The key of the user task to assign. */
-		userTaskKey: string
-		/** The assignee for the user task. The assignee must not be empty or null. */
-		assignee: string
-		/** By default, the task is reassigned if it was already assigned. Set this to false to return an error in such cases. The task must then first be unassigned to be assigned again. Use this when you have users picking from group task queues to prevent race conditions. */
-		allowOverride?: boolean
-		/** A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to "assign". */
-		action: string
-	}) {
+	}: AssignUserTaskRequest): Promise<void> {
+		return this.assignUserTask({ userTaskKey, assignee, allowOverride, action })
+	}
+
+	/**
+	 * Assign a user task with the given key to the given assignee.
+	 *
+	 * Documentation: https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/assign-user-task/
+	 *
+	 * @since 8.6.0
+	 */
+	public async assignUserTask({
+		userTaskKey,
+		assignee,
+		allowOverride = true,
+		action = 'assign',
+	}: AssignUserTaskRequest): Promise<void> {
 		const headers = await this.getHeaders()
 		const req = {
 			allowOverride,
@@ -304,6 +314,7 @@ export class CamundaRestClient {
 	 * Documentation: https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/update-user-task/
 	 *
 	 * @since 8.6.0
+	 * @deprecated use `updateUserTask`
 	 */
 	public async updateTask({
 		userTaskKey,
@@ -312,6 +323,23 @@ export class CamundaRestClient {
 		userTaskKey: string
 		changeset: TaskChangeSet
 	}) {
+		return this.updateUserTask({ userTaskKey, changeset })
+	}
+
+	/**
+	 * Update a user task with the given key.
+	 *
+	 * Documentation: https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/update-user-task/
+	 *
+	 * @since 8.6.0
+	 */
+	public async updateUserTask({
+		userTaskKey,
+		changeset,
+	}: {
+		userTaskKey: string
+		changeset: TaskChangeSet
+	}): Promise<void> {
 		const headers = await this.getHeaders()
 		return this.rest.then((rest) =>
 			rest
@@ -322,6 +350,23 @@ export class CamundaRestClient {
 				.json()
 		)
 	}
+
+	/**
+	 * Remove the assignee of a task with the given key.
+	 *
+	 * Documentation: https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/unassign-user-task/
+	 *
+	 * @since 8.6.0
+	 * @deprecated use `unassignUserTask`
+	 */
+	public async unassignTask({
+		userTaskKey,
+	}: {
+		userTaskKey: string
+	}): Promise<void> {
+		return this.unassignUserTask({ userTaskKey })
+	}
+
 	/**
 	 * Remove the assignee of a task with the given key.
 	 *
@@ -329,7 +374,11 @@ export class CamundaRestClient {
 	 *
 	 * @since 8.6.0
 	 */
-	public async unassignTask({ userTaskKey }: { userTaskKey: string }) {
+	public async unassignUserTask({
+		userTaskKey,
+	}: {
+		userTaskKey: string
+	}): Promise<void> {
 		const headers = await this.getHeaders()
 		return this.rest.then((rest) =>
 			rest.delete(`user-tasks/${userTaskKey}/assignee`, { headers }).json()


### PR DESCRIPTION
## Description of the change

[Describe your changes here]

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
