### PR TITLE
fix(camunda8): standardise on search for methods. closes #363

### DIFF
--- a/src/__tests__/8.7-sm-only/userTasks.rest.spec.ts
+++ b/src/__tests__/8.7-sm-only/userTasks.rest.spec.ts
@@ -34,8 +34,10 @@ test('It can complete a user task', async () => {
 	await new Promise((resolve) => setTimeout(resolve, 500))
 
 	// Poll until we find a task
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let availableTasks: SearchUserTasksResponse = { page: 1, items: [] } as any
+	let availableTasks: SearchUserTasksResponse = {
+		page: { totalItems: 0, lastSortValues: [], firstSortValues: [] },
+		items: [],
+	}
 	const maxAttempts = 200
 	let attempts = 0
 

--- a/src/__tests__/8.7-sm-only/userTasks.rest.spec.ts
+++ b/src/__tests__/8.7-sm-only/userTasks.rest.spec.ts
@@ -5,7 +5,7 @@
  */
 import path from 'node:path'
 
-import { QueryUserTasksResponse } from 'c8/lib/C8Dto'
+import { SearchUserTasksResponse } from 'c8/lib/C8Dto'
 
 import { CamundaRestClient } from '../../c8/lib/CamundaRestClient'
 
@@ -35,7 +35,7 @@ test('It can complete a user task', async () => {
 
 	// Poll until we find a task
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let availableTasks: QueryUserTasksResponse = { page: 1, items: [] } as any
+	let availableTasks: SearchUserTasksResponse = { page: 1, items: [] } as any
 	const maxAttempts = 200
 	let attempts = 0
 

--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -356,23 +356,23 @@ export interface RestJob<
 	readonly tenantId: string
 }
 
-interface QueryPageRequestSearchAfter {
+interface SearchPageRequestSearchAfter {
 	from: number
 	limit: number
 	// example: [{}]. Pass in the lastSortValues from the previous response.
 	searchAfter?: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-interface QueryPageRequestSearchBefore {
+interface SearchPageRequestSearchBefore {
 	from: number
 	limit: number
 	// example: [{}]. Pass in the lastSortValues from the previous response.
 	searchBefore?: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-export type QueryPageRequest =
-	| QueryPageRequestSearchAfter
-	| QueryPageRequestSearchBefore
+export type SearchPageRequest =
+	| SearchPageRequestSearchAfter
+	| SearchPageRequestSearchBefore
 
 export interface AdvancedStringFilter {
 	/** Checks for equality with the provided value. */
@@ -398,7 +398,7 @@ export interface AdvancedNumberFilter {
 	$lte: number
 }
 
-export interface QueryFilterRequest {
+export interface SearchFilterRequest {
 	/** The key for this variable. */
 	variableKey?: string | AdvancedStringFilter
 	/** Name of the variable. */
@@ -415,22 +415,22 @@ export interface QueryFilterRequest {
 	isTruncated?: boolean
 }
 
-export interface QuerySortRequest {
+export interface SearchSortRequest {
 	field: string
 	/** The order in which to sort the related field. Default value: ASC */
 	order?: 'ASC' | 'DESC'
 }
 
-export interface QueryVariablesRequest {
+export interface SearchVariablesRequest {
 	/** Sort field criteria. */
-	sort?: QuerySortRequest
+	sort?: SearchSortRequest
 	/** Pagination criteria. */
-	page?: QueryPageRequest
+	page?: SearchPageRequest
 	/** Variable filter request. */
-	filter: QueryFilterRequest
+	filter: SearchFilterRequest
 }
 
-export interface QueryResponsePagination {
+export interface SearchResponsePagination {
 	/** Total items matching the criteria. */
 	totalItems: number
 	/** The sort values of the first item in the result set. Use this in the searchBefore field of an ensuing request. */
@@ -439,9 +439,9 @@ export interface QueryResponsePagination {
 	lastSortValues: unknown[]
 }
 
-export interface QueryVariablesResponse {
+export interface SearchVariablesResponse {
 	/** Pagination information about the search results. */
-	page: QueryResponsePagination
+	page: SearchResponsePagination
 	/** The matching variables. */
 	items: Array<{
 		/** The key for this variable. */
@@ -453,7 +453,7 @@ export interface QueryVariablesResponse {
 	}>
 }
 
-export type QueryUserTasksSortRequest = Array<{
+export type SearchUserTasksSortRequest = Array<{
 	/** The field to sort by. */
 	field:
 		| 'creationDate'
@@ -485,7 +485,7 @@ export interface AdvancedDateTimeFilter {
 }
 
 /** User task filter request. */
-export interface QueryUserTasksFilter {
+export interface SearchUserTasksFilter {
 	/** The key for this user task. */
 	userTaskKey?: string
 	/** The state of the user task. */
@@ -534,17 +534,17 @@ export interface QueryUserTasksFilter {
 	}>
 }
 
-export interface QueryTasksRequest {
+export interface SearchTasksRequest {
 	/** Pagination criteria. */
-	page?: QueryPageRequest
+	page?: SearchPageRequest
 	/** Sort field criteria. */
-	sort?: QueryUserTasksSortRequest
+	sort?: SearchUserTasksSortRequest
 	/** User task filter request. */
-	filter?: QueryUserTasksFilter
+	filter?: SearchUserTasksFilter
 }
 
-export interface QueryUserTasksResponse {
-	page: QueryResponsePagination
+export interface SearchUserTasksResponse {
+	page: SearchResponsePagination
 	items: Array<{
 		/** The key of the user task. */
 		userTaskKey: string
@@ -633,7 +633,7 @@ export interface UserTaskVariablesSortRequest {
 export interface UserTaskVariablesRequest {
 	userTaskKey: string
 	/** Pagination criteria. */
-	page?: QueryPageRequest
+	page?: SearchPageRequest
 	/** Sort field criteria. */
 	sort: UserTaskVariablesSortRequest[]
 	/** The user task variable search filters. */
@@ -646,7 +646,7 @@ export interface UserTaskVariablesRequest {
 /** The user task variables search response. */
 export interface UserTaskVariablesResponse {
 	/** Pagination information about the search results. */
-	page: QueryResponsePagination
+	page: SearchResponsePagination
 	/** The matching variables. */
 	items: Array<{
 		/** The key for this variable. */
@@ -676,9 +676,9 @@ export interface AdvancedProcessInstanceStateFilter {
 }
 
 /** This is the 8.8 API.  */
-export interface QueryProcessInstanceRequest {
+export interface SearchProcessInstanceRequest {
 	/** Pagination criteria. */
-	page?: QueryPageRequest
+	page?: SearchPageRequest
 	/** Sort field criteria. */
 	sort: Array<{
 		field:
@@ -734,8 +734,8 @@ export interface QueryProcessInstanceRequest {
 	}
 }
 
-export interface QueryProcessInstanceResponse {
-	page: QueryResponsePagination
+export interface SearchProcessInstanceResponse {
+	page: SearchResponsePagination
 	items: Array<{
 		/** The key of the process instance. */
 		processInstanceKey: string

--- a/src/c8/lib/CamundaRestClient.ts
+++ b/src/c8/lib/CamundaRestClient.ts
@@ -59,13 +59,13 @@ import {
 	PatchAuthorizationRequest,
 	ProcessDeployment,
 	PublishMessageResponse,
-	QueryProcessInstanceRequest,
-	QueryProcessInstanceResponse,
-	QueryTasksRequest,
-	QueryUserTasksResponse,
-	QueryVariablesRequest,
-	QueryVariablesResponse,
 	RestJob,
+	SearchProcessInstanceRequest,
+	SearchProcessInstanceResponse,
+	SearchTasksRequest,
+	SearchUserTasksResponse,
+	SearchVariablesRequest,
+	SearchVariablesResponse,
 	TaskChangeSet,
 	UpdateElementVariableRequest,
 	UploadDocumentRequest,
@@ -397,8 +397,8 @@ export class CamundaRestClient {
 	 * @since 8.8.0 - alpha status in 8.6 and 8.7
 	 */
 	public async searchUserTasks(
-		request: QueryTasksRequest
-	): Promise<QueryUserTasksResponse> {
+		request: SearchTasksRequest
+	): Promise<SearchUserTasksResponse> {
 		const headers = await this.getHeaders()
 		const page = request.page ?? {
 			from: 0,
@@ -411,7 +411,7 @@ export class CamundaRestClient {
 					headers,
 					body: losslessStringify({ ...request, page, sort }),
 				})
-				.json<QueryUserTasksResponse>()
+				.json<SearchUserTasksResponse>()
 		)
 		/**
 		 * The 8.6 and 8.7 API have different key names for the userTaskKey. This code block normalizes the key names.
@@ -488,9 +488,9 @@ export class CamundaRestClient {
 	 * Search for user tasks based on given criteria.
 	 *
 	 * Documentation: https://docs.camunda.io/docs/apis-tools/camunda-api-rest/specifications/query-user-tasks-alpha/
-	 * @experimental
+	 * @since 8.8.0
 	 */
-	// public async queryTasks() {}
+	// public async searchUserTasks() {}
 
 	/**
 	 * Publish a Message and correlates it to a subscription. If correlation is successful it will return the first process instance key the message correlated with.
@@ -870,8 +870,8 @@ export class CamundaRestClient {
 	 * @since 8.8.0
 	 */
 	public async searchProcessInstances(
-		request: QueryProcessInstanceRequest
-	): Promise<QueryProcessInstanceResponse> {
+		request: SearchProcessInstanceRequest
+	): Promise<SearchProcessInstanceResponse> {
 		const headers = await this.getHeaders()
 		const page = request.page ?? {
 			from: 0,
@@ -883,7 +883,7 @@ export class CamundaRestClient {
 					headers,
 					body: losslessStringify({ ...request, page }),
 				})
-				.json<QueryProcessInstanceResponse>()
+				.json<SearchProcessInstanceResponse>()
 		)
 	}
 
@@ -1120,8 +1120,8 @@ export class CamundaRestClient {
 	 * @since 8.8.0
 	 */
 	public async searchVariables(
-		req: QueryVariablesRequest
-	): Promise<QueryVariablesResponse> {
+		req: SearchVariablesRequest
+	): Promise<SearchVariablesResponse> {
 		const headers = await this.getHeaders()
 		return this.rest.then((rest) =>
 			rest


### PR DESCRIPTION
## Description of the change

Rename Dtos for search methods over the REST API.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This will be a breaking change for anyone using the Dtos for the search methods - which should be no-one right now, because this is in alpha in 8.6/8.7.
