### PR TITLE
feat: make activeJobs REST calls cancelable. fixes #424

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"long": "^4.0.0",
 				"lossless-json": "^4.0.1",
 				"neon-env": "^0.1.3",
+				"p-cancelable": "^2.1.1",
 				"promise-retry": "^1.1.1",
 				"reflect-metadata": "^0.2.1",
 				"stack-trace": "0.0.10",
@@ -15412,6 +15413,8 @@
 		},
 		"node_modules/p-cancelable": {
 			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
 		"long": "^4.0.0",
 		"lossless-json": "^4.0.1",
 		"neon-env": "^0.1.3",
+		"p-cancelable": "^2.1.1",
 		"promise-retry": "^1.1.1",
 		"reflect-metadata": "^0.2.1",
 		"stack-trace": "0.0.10",

--- a/src/__tests__/c8/rest/jobWorker.rest.spec.ts
+++ b/src/__tests__/c8/rest/jobWorker.rest.spec.ts
@@ -1,0 +1,24 @@
+import { CamundaRestClient } from '../../../c8/lib/CamundaRestClient'
+
+// https://github.com/camunda/camunda-8-js-sdk/issues/424
+test('REST worker will cancel inflight call on close', (done) => {
+	const restClient = new CamundaRestClient({
+		config: {
+			CAMUNDA_LOG_LEVEL: 'none',
+		},
+	})
+	const restJobWorker = restClient.createJobWorker({
+		type: 'unauthenticated-worker',
+		jobHandler: async () => {
+			throw new Error('Not Implemented') // is never called
+		},
+		worker: 'unauthenticated-test-worker',
+		maxJobsToActivate: 10,
+		timeout: 30000,
+	})
+
+	setTimeout(() => {
+		restJobWorker.stop()
+		done()
+	}, 3000)
+})

--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -3,7 +3,13 @@ import { ReadStream } from 'fs'
 import { LosslessNumber } from 'lossless-json'
 
 import { ChildDto, Int64String, LosslessDto } from '../../lib'
-import { ICustomHeaders, IInputVariables, JSONDoc } from '../../zeebe/types'
+import {
+	ICustomHeaders,
+	IInputVariables,
+	IProcessVariables,
+	JobCompletionInterfaceRest,
+	JSONDoc,
+} from '../../zeebe/types'
 
 export class RestApiJob<
 	Variables = LosslessDto,
@@ -355,6 +361,12 @@ export interface RestJob<
 	 */
 	readonly tenantId: string
 }
+
+export type JobWithMethods<VariablesDto, CustomHeadersDto> = RestJob<
+	VariablesDto,
+	CustomHeadersDto
+> &
+	JobCompletionInterfaceRest<IProcessVariables>
 
 interface SearchPageRequestSearchAfter {
 	from: number
@@ -972,7 +984,8 @@ export class EvaluateDecisionResponse extends LosslessDto {
 	evaluatedDecisions!: EvaluatedDecision[]
 }
 
-export interface ApiEndpointRequest<T> {
+// Base interface with common properties
+export interface BaseApiEndpointRequest<T> {
 	method: 'GET' | 'POST' | 'PUT' | 'DELETE'
 	/** The URL path of the API endpoint. */
 	urlPath: string
@@ -987,3 +1000,20 @@ export interface ApiEndpointRequest<T> {
 	/** A custom JSON parsing function */
 	parseJson?: typeof JSON.parse
 }
+
+// Interface for requests that return JSON (json=true or undefined)
+export interface JsonApiEndpointRequest<T> extends BaseApiEndpointRequest<T> {
+	/** JSON-parse response? Default: true */
+	json?: true | undefined
+}
+
+// Interface for requests that return raw response (json=false)
+export interface RawApiEndpointRequest<T> extends BaseApiEndpointRequest<T> {
+	/** JSON-parse response? */
+	json: false
+}
+
+// Combined type for use in function signatures
+export type ApiEndpointRequest<T> =
+	| JsonApiEndpointRequest<T>
+	| RawApiEndpointRequest<T>

--- a/src/c8/lib/CamundaJobWorker.ts
+++ b/src/c8/lib/CamundaJobWorker.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events'
 
+import PCancelable from 'p-cancelable'
 import TypedEmitter from 'typed-emitter'
 
 import { LosslessDto } from '../../lib'
@@ -10,7 +11,7 @@ import {
 	MustReturnJobActionAcknowledgement,
 } from '../../zeebe/types'
 
-import { Ctor, RestJob } from './C8Dto'
+import { Ctor, JobWithMethods, RestJob } from './C8Dto'
 import { getLogger, Logger } from './C8Logger'
 import { CamundaRestClient } from './CamundaRestClient'
 
@@ -74,6 +75,9 @@ export class CamundaJobWorker<
 		currentload: number
 	}
 	stopping: boolean = false
+	private activePoll?: PCancelable<
+		JobWithMethods<VariablesDto, CustomHeadersDto>[]
+	>
 
 	constructor(
 		private readonly config: CamundaJobWorkerConfig<
@@ -121,6 +125,14 @@ export class CamundaJobWorker<
 		clearTimeout(this.backoffTimer)
 		/** Do not allow the backoff retry to restart polling */
 		clearTimeout(this.backoffTimer)
+		// Cancel the active poll if it exists
+		// See: https://github.com/camunda/camunda-8-js-sdk/issues/424
+		if (this.activePoll && !this.activePoll.isCanceled) {
+			this.activePoll.cancel('Worker stopped')
+			this.log.debug(`Active poll cancelled`, this.logMeta())
+			this.activePoll = undefined
+		}
+
 		return new Promise((resolve, reject) => {
 			if (this.currentlyActiveJobCount === 0) {
 				this.log.debug(`All jobs drained. Worker stopped.`, this.logMeta())
@@ -173,11 +185,12 @@ export class CamundaJobWorker<
 
 		const remainingJobCapacity =
 			this.config.maxJobsToActivate - this.currentlyActiveJobCount
-		this.restClient
-			.activateJobs({
-				...this.config,
-				maxJobsToActivate: remainingJobCapacity,
-			})
+		this.activePoll = this.restClient.activateJobs({
+			...this.config,
+			maxJobsToActivate: remainingJobCapacity,
+		})
+
+		this.activePoll
 			.then((jobs) => {
 				const count = jobs.length
 				this.currentlyActiveJobCount += count
@@ -189,12 +202,13 @@ export class CamundaJobWorker<
 				this.backoffRetryCount = 0
 			})
 			.catch((e) => {
-				// This can throw a 400 or 500 REST Error with the Content-Type application/problem+json
+				// This can throw a 400, 401, or 500 REST Error with the Content-Type application/problem+json
 				// The schema is:
 				// { type: string, title: string, status: number, detail: string, instance: string }
 				this.log.error('Error during job worker poll')
 				this.log.error(e)
 				this.emit('pollError', e)
+				this.activePoll = undefined
 				const backoffDuration = Math.min(
 					2000 * ++this.backoffRetryCount,
 					this.maxBackoffTimeMs

--- a/src/lib/Configuration.ts
+++ b/src/lib/Configuration.ts
@@ -29,11 +29,20 @@ const getMainEnv = () =>
 			optional: true,
 			default: 1000,
 		},
-		/** The log level for logging. Defaults to 'info'. Values (in order of priority): 'error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly' */
+		/** The log level for logging. Defaults to 'info'. Values (in order of priority): 'error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'. Set to 'none' to suppress logging. */
 		CAMUNDA_LOG_LEVEL: {
 			type: 'string',
 			optional: true,
-			choices: ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'],
+			choices: [
+				'error',
+				'warn',
+				'info',
+				'http',
+				'verbose',
+				'debug',
+				'silly',
+				'none',
+			],
 			default: 'info',
 		},
 		/** The address for the Zeebe GRPC. */


### PR DESCRIPTION
## Description of the change

This PR makes activeJobs REST calls cancelable by updating the REST client to return PCancelable promises and integrating cancellation handling into the job worker.

Updated configuration adds an option ('none') to suppress logging.
Modified CamundaRestClient methods (activateJobs and callApiEndpoint) to support cancellation using PCancelable, and refactored related types.
Enhanced job worker cancellation logic and added tests to verify cancellation behavior.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
