### PR TITLE
Rename `CorrelateMessageResponse` DTO `key` property to `messageKey`

### DIFF
--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -209,7 +209,7 @@ export interface UpdateElementVariableRequest {
 export class CorrelateMessageResponse extends LosslessDto {
 	/** the unique ID of the message that was published */
 	@Int64String
-	key!: string
+	messageKey!: string
 	/** the tenantId of the message */
 	tenantId!: string
 	/** The key of the first process instance the message correlated with */


### PR DESCRIPTION
## Description of the change

Renamed the `key` property in `CorrelateMessageResponse` to `messageKey` to match the API response.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [X] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)