### PR TITLE
fix: update documentation around TLS and mTLS configuration, fixes #395

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ const c8 = new Camunda8({
 
 If the cache directory does not exist, the SDK will attempt to create it (recursively). If the SDK is unable to create it, or the directory exists but is not writeable by your application, the SDK will throw an exception.
 
+## TLS
+
+If you are using self-signed certificates, you can provide the self-signed certificate path using the configuration parameter / environment variable: `CAMUNDA_CUSTOM_ROOT_CERT_PATH`.
+
+### mTLS
+
+The Zeebe gRPC client supports mTLS. You can provide the mTLS certificate and key with:
+
+```
+CAMUNDA_CUSTOM_CERT_CHAIN_PATH # path to mTLS certificate
+CAMUNDA_CUSTOM_PRIVATE_KEY_PATH # path to mTLS (client-side) key
+```
+
 ## Connection configuration examples
 
 ### Self-Managed

--- a/src/lib/Configuration.ts
+++ b/src/lib/Configuration.ts
@@ -175,22 +175,22 @@ const getMainEnv = () =>
 			optional: true,
 			default: 'demo',
 		},
-		/** In an environment using self-signed certificates, provide the path to the root certificate */
+		/** In an environment using self-signed certificates, provide the path to the server certificate. Provide this to allow the client to connect to a server secured with this cert. */
 		CAMUNDA_CUSTOM_ROOT_CERT_PATH: {
 			type: 'string',
 			optional: true,
 		},
-		/** When using self-signed certificates, provide the root certificate as a string */
+		/** In an environment using self-signed certificates, provide the server certificate as a string. Provide this to allow the client to connect to a server secured with this cert. */
 		CAMUNDA_CUSTOM_ROOT_CERT_STRING: {
 			type: 'string',
 			optional: true,
 		},
-		/** When using custom or self-signed certificates, provide the path to the certificate chain */
+		/** When using custom or self-signed certificates with mTLS, provide the path to the client certificate chain. Works with Zeebe gRPC. */
 		CAMUNDA_CUSTOM_CERT_CHAIN_PATH: {
 			type: 'string',
 			optional: true,
 		},
-		/** When using custom or self-signed certificates, provide the path to the private key */
+		/** When using custom or self-signed certificates with mTLS, provide the path to the client private key. Works with Zeebe gRPC. */
 		CAMUNDA_CUSTOM_PRIVATE_KEY_PATH: {
 			type: 'string',
 			optional: true,


### PR DESCRIPTION
## Description of the change

This pull request updates the documentation and comments related to TLS and mTLS configuration.

Updated comments in Configuration.ts to clarify the usage of certificates and keys for both TLS and mTLS.
Added a new TLS/mTLS section in the README to guide users on configuring these settings.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
