### PR TITLE
fix: rename messageKey in PublishMessageResponse Dto

### DIFF
--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -220,7 +220,7 @@ export class CorrelateMessageResponse extends LosslessDto {
 export class PublishMessageResponse extends LosslessDto {
 	/** the unique ID of the message that was published */
 	@Int64String
-	key!: string
+	messageKey!: string
 	/** the tenantId of the message */
 	tenantId!: string
 }


### PR DESCRIPTION
## Description of the change

This PR renames the property in the PublishMessageResponse DTO to align with the API.

Renamed the property from "key" to "messageKey".

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

