### PR TITLE
Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ CAMUNDA_AUTH_STRATEGY=BEARER
 CAMUNDA_OAUTH_TOKEN=....
 ```
 
+To refresh the bearer token dynamically at runtime (for example, when it has expired), call `CamundaRestClient.setBearerToken(newTokenValue)`. This will also update the bearer token for all workers created by this client.
+
 ### Cookie Auth
 
 For C8Run with 8.7, you need to use [Cookie Authentication](https://docs.camunda.io/docs/apis-tools/camunda-api-rest/camunda-api-rest-authentication/#authentication-via-cookie-c8run-only).

--- a/src/__tests__/c8/rest/refreshBearerToken.unit.spec.ts
+++ b/src/__tests__/c8/rest/refreshBearerToken.unit.spec.ts
@@ -1,0 +1,29 @@
+import { CamundaRestClient } from '../../../c8/lib/CamundaRestClient'
+import { Camunda8ClientConfiguration } from '../../../lib/Configuration'
+import { IOAuthProvider } from '../../../oauth'
+
+class TestCamundaRestClient extends CamundaRestClient {
+	constructor(options?: {
+		config?: Camunda8ClientConfiguration
+		oAuthProvider?: IOAuthProvider
+	}) {
+		super(options)
+	}
+	getBearerToken() {
+		return this.oAuthProvider.getToken('ZEEBE')
+	}
+}
+
+test('it can refresh the bearer token', async () => {
+	const client = new TestCamundaRestClient({
+		config: {
+			CAMUNDA_AUTH_STRATEGY: 'BEARER',
+			CAMUNDA_OAUTH_TOKEN: 'initialToken',
+		},
+	})
+	const initialToken = await client.getBearerToken()
+	expect(initialToken.authorization).toEqual('Bearer initialToken')
+	client.setBearerToken('newToken')
+	const newToken = await client.getBearerToken()
+	expect(newToken.authorization).toEqual('Bearer newToken')
+})

--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -220,7 +220,7 @@ export class CorrelateMessageResponse extends LosslessDto {
 export class PublishMessageResponse extends LosslessDto {
 	/** the unique ID of the message that was published */
 	@Int64String
-	key!: string
+	messageKey!: string
 	/** the tenantId of the message */
 	tenantId!: string
 }

--- a/src/c8/lib/CamundaRestClient.ts
+++ b/src/c8/lib/CamundaRestClient.ts
@@ -23,6 +23,7 @@ import {
 	RequireConfiguration,
 } from '../../lib'
 import { IOAuthProvider } from '../../oauth'
+import { BearerAuthProvider } from '../../oauth/lib/BearerAuthProvider'
 import {
 	ActivateJobsRequest,
 	BroadcastSignalReq,
@@ -104,7 +105,7 @@ class DefaultLosslessDto extends LosslessDto {}
  */
 export class CamundaRestClient {
 	private userAgentString: string
-	private oAuthProvider: IOAuthProvider
+	protected oAuthProvider: IOAuthProvider
 	private rest: Promise<typeof got>
 	private tenantId?: string
 	public log: Logger
@@ -1433,6 +1434,13 @@ export class CamundaRestClient {
 				reject(e)
 			}
 		})
+	}
+
+	/** Dynamically update the bearer token used to authorise requests. This only has an effect when using the Bearer auth strategy. */
+	public setBearerToken(bearerToken: string) {
+		if (this.oAuthProvider instanceof BearerAuthProvider) {
+			this.oAuthProvider.setToken(bearerToken)
+		}
 	}
 
 	/**

--- a/src/oauth/lib/BearerAuthProvider.ts
+++ b/src/oauth/lib/BearerAuthProvider.ts
@@ -11,7 +11,7 @@ import { IOAuthProvider } from '../index'
 import { TokenGrantAudienceType } from './IOAuthProvider'
 
 export class BearerAuthProvider implements IOAuthProvider {
-	private bearerToken: string
+	protected bearerToken: string
 
 	constructor(options?: {
 		config?: DeepPartial<CamundaPlatform8Configuration>
@@ -30,5 +30,9 @@ export class BearerAuthProvider implements IOAuthProvider {
 		debug(`Token request for ${audienceType}`)
 
 		return Promise.resolve({ authorization: `Bearer ${this.bearerToken}` })
+	}
+
+	public setToken(bearerToken: string) {
+		this.bearerToken = bearerToken
 	}
 }


### PR DESCRIPTION
## Description of the change

This PR introduces a method to dynamically update the bearer token used for authorizing requests. Key changes include:

Changing the access modifier of bearerToken from private to protected in BearerAuthProvider.
Adding a new public method (setToken) in BearerAuthProvider to update the bearer token.
Exposing a new setBearerToken method in CamundaRestClient for refreshing the token at runtime.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


