### PR TITLE
feat: enable arbitrary headers on requests. fixes #448

### DIFF
--- a/src/__tests__/c8/rest/refreshBearerToken.unit.spec.ts
+++ b/src/__tests__/c8/rest/refreshBearerToken.unit.spec.ts
@@ -1,6 +1,17 @@
+import path from 'path'
+
+import { Server, ServerCredentials, loadPackageDefinition } from '@grpc/grpc-js'
+import { loadSync } from '@grpc/proto-loader'
+
+import { Camunda8 } from '../../../c8'
 import { CamundaRestClient } from '../../../c8/lib/CamundaRestClient'
+import {
+	BrokerInfo,
+	Partition,
+	TopologyResponse,
+} from '../../../generated/zeebe_pb'
 import { Camunda8ClientConfiguration } from '../../../lib/Configuration'
-import { IOAuthProvider } from '../../../oauth'
+import { BearerAuthProvider, IOAuthProvider } from '../../../oauth'
 
 class TestCamundaRestClient extends CamundaRestClient {
 	constructor(options?: {
@@ -26,4 +37,84 @@ test('it can refresh the bearer token', async () => {
 	client.setBearerToken('newToken')
 	const newToken = await client.getBearerToken()
 	expect(newToken.authorization).toEqual('Bearer newToken')
+})
+
+test('it can refresh the bearer token with a custom OAuth provider', async () => {
+	let currentToken = ''
+
+	function createServer(): Promise<{ server: Server; port: number }> {
+		return new Promise((resolve, reject) => {
+			// Load the protobuf definition
+			const packageDefinition = loadSync(
+				path.join(__dirname, '..', '..', '..', 'proto', 'zeebe.proto'),
+				{
+					keepCase: true,
+					longs: String,
+					enums: String,
+					defaults: true,
+					oneofs: true,
+				}
+			)
+
+			const zeebeProto = loadPackageDefinition(
+				packageDefinition
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			) as unknown as { gateway_protocol: { Gateway: any } }
+
+			// Create the server
+			const server = new Server()
+
+			// Add a service to the server
+			server.addService(zeebeProto.gateway_protocol.Gateway.service, {
+				Topology: (_, callback) => {
+					const t = new TopologyResponse()
+					const b = new BrokerInfo()
+					b.setHost('localhost')
+					const partition = new Partition()
+					partition.setHealth(0)
+					partition.setPartitionid(0)
+					partition.setRole(0)
+					b.setPartitionsList([partition])
+					t.setBrokersList([b])
+					currentToken = _.metadata.get('authorization')[0]
+					callback(null, t)
+				},
+				// Implement your service methods here
+			})
+
+			const credentials = ServerCredentials.createInsecure()
+			// Start the server
+			server.bindAsync('localhost:50051', credentials, (err, port) => {
+				if (err) {
+					reject(err)
+				}
+				resolve({ server, port })
+			})
+		})
+	}
+
+	const bearerAuth = new BearerAuthProvider({
+		config: {
+			CAMUNDA_OAUTH_TOKEN: 'initialToken',
+		},
+	})
+
+	const c8 = new Camunda8({ oAuthProvider: bearerAuth })
+	bearerAuth.setToken('newToken')
+	const { server, port } = await createServer()
+	const zbc = c8.getZeebeGrpcApiClient({
+		CAMUNDA_OAUTH_DISABLED: true,
+		ZEEBE_ADDRESS: `localhost:${port}`,
+		CAMUNDA_SECURE_CONNECTION: false,
+		zeebeGrpcSettings: {
+			ZEEBE_CLIENT_LOG_LEVEL: 'NONE',
+			ZEEBE_INSECURE_CONNECTION: true,
+		},
+	})
+	await zbc.topology()
+	expect(currentToken).toEqual('Bearer newToken')
+	bearerAuth.setToken('somethingElse')
+	await zbc.topology()
+	expect(currentToken).toEqual('Bearer somethingElse')
+	server.tryShutdown((e) => e && console.error(e))
 })

--- a/src/__tests__/c8/rest/refreshBearerToken.unit.spec.ts
+++ b/src/__tests__/c8/rest/refreshBearerToken.unit.spec.ts
@@ -4,40 +4,12 @@ import { Server, ServerCredentials, loadPackageDefinition } from '@grpc/grpc-js'
 import { loadSync } from '@grpc/proto-loader'
 
 import { Camunda8 } from '../../../c8'
-import { CamundaRestClient } from '../../../c8/lib/CamundaRestClient'
 import {
 	BrokerInfo,
 	Partition,
 	TopologyResponse,
 } from '../../../generated/zeebe_pb'
-import { Camunda8ClientConfiguration } from '../../../lib/Configuration'
-import { BearerAuthProvider, IOAuthProvider } from '../../../oauth'
-
-class TestCamundaRestClient extends CamundaRestClient {
-	constructor(options?: {
-		config?: Camunda8ClientConfiguration
-		oAuthProvider?: IOAuthProvider
-	}) {
-		super(options)
-	}
-	getBearerToken() {
-		return this.oAuthProvider.getToken('ZEEBE')
-	}
-}
-
-test('it can refresh the bearer token', async () => {
-	const client = new TestCamundaRestClient({
-		config: {
-			CAMUNDA_AUTH_STRATEGY: 'BEARER',
-			CAMUNDA_OAUTH_TOKEN: 'initialToken',
-		},
-	})
-	const initialToken = await client.getBearerToken()
-	expect(initialToken.authorization).toEqual('Bearer initialToken')
-	client.setBearerToken('newToken')
-	const newToken = await client.getBearerToken()
-	expect(newToken.authorization).toEqual('Bearer newToken')
-})
+import { BearerAuthProvider } from '../../../oauth'
 
 test('it can refresh the bearer token with a custom OAuth provider', async () => {
 	let currentToken = ''

--- a/src/c8/index.ts
+++ b/src/c8/index.ts
@@ -50,10 +50,18 @@ export class Camunda8 {
 	/**
 	 * All constructor parameters for configuration are optional. If no configuration is provided, the SDK will use environment variables to configure itself.
 	 */
-	constructor(config: Camunda8ClientConfiguration = {}) {
+
+	constructor(
+		config: Camunda8ClientConfiguration & {
+			oAuthProvider?: IOAuthProvider
+		} = {}
+	) {
 		this.configuration =
 			CamundaEnvironmentConfigurator.mergeConfigWithEnvironment(config)
-		this.oAuthProvider = constructOAuthProvider(this.configuration)
+		// Allow custom oAuthProvider to be passed in.
+		// See: https://github.com/camunda/camunda-8-js-sdk/issues/448
+		this.oAuthProvider =
+			config.oAuthProvider ?? constructOAuthProvider(this.configuration)
 		this.log = getLogger(config)
 		this.log.debug('Camunda8 SDK initialized')
 	}

--- a/src/c8/lib/CamundaRestClient.ts
+++ b/src/c8/lib/CamundaRestClient.ts
@@ -23,7 +23,6 @@ import {
 	RequireConfiguration,
 } from '../../lib'
 import { IOAuthProvider } from '../../oauth'
-import { BearerAuthProvider } from '../../oauth/lib/BearerAuthProvider'
 import {
 	ActivateJobsRequest,
 	BroadcastSignalReq,
@@ -1434,13 +1433,6 @@ export class CamundaRestClient {
 				reject(e)
 			}
 		})
-	}
-
-	/** Dynamically update the bearer token used to authorise requests. This only has an effect when using the Bearer auth strategy. */
-	public setBearerToken(bearerToken: string) {
-		if (this.oAuthProvider instanceof BearerAuthProvider) {
-			this.oAuthProvider.setToken(bearerToken)
-		}
 	}
 
 	/**

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -12,7 +12,9 @@ export interface TokenError {
 	error_description: string
 }
 
+export { BearerAuthProvider } from './lib/BearerAuthProvider'
 export { CookieAuthProvider } from './lib/CookieAuthProvider'
 export { IOAuthProvider } from './lib/IOAuthProvider'
 export { NullAuthProvider } from './lib/NullAuthProvider'
 export { OAuthProvider } from './lib/OAuthProvider'
+

--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -17,4 +17,3 @@ export { CookieAuthProvider } from './lib/CookieAuthProvider'
 export { IOAuthProvider } from './lib/IOAuthProvider'
 export { NullAuthProvider } from './lib/NullAuthProvider'
 export { OAuthProvider } from './lib/OAuthProvider'
-

--- a/src/oauth/lib/BearerAuthProvider.ts
+++ b/src/oauth/lib/BearerAuthProvider.ts
@@ -32,6 +32,12 @@ export class BearerAuthProvider implements IOAuthProvider {
 		return Promise.resolve({ authorization: `Bearer ${this.bearerToken}` })
 	}
 
+	/**
+	 * Updates the bearer token used for authentication.
+	 *
+	 * @param bearerToken - The new bearer token to be used. This should be a valid
+	 *                      token string obtained from a trusted source.
+	 */
 	public setToken(bearerToken: string) {
 		this.bearerToken = bearerToken
 	}

--- a/src/oauth/lib/IOAuthProvider.ts
+++ b/src/oauth/lib/IOAuthProvider.ts
@@ -9,9 +9,8 @@ export type TokenGrantAudienceType =
 export type AuthHeader = {
 	[K in 'authorization' | 'cookie']?: string
 }
-
 export type HeadersPromise = Promise<AuthHeader>
 
-export interface IOAuthProvider {
-	getToken(audience: TokenGrantAudienceType): HeadersPromise
+export interface IOAuthProvider<T = AuthHeader> {
+	getToken(audience: TokenGrantAudienceType): Promise<T>
 }

--- a/src/zeebe/lib/GrpcClient.ts
+++ b/src/zeebe/lib/GrpcClient.ts
@@ -543,8 +543,12 @@ export class GrpcClient extends EventEmitter {
 		const metadata = new Metadata({ waitForReady: false })
 		metadata.add('user-agent', this.userAgentString)
 		if (this.oAuth) {
-			const authorization = await this.oAuth.getToken('ZEEBE')
-			metadata.add('Authorization', authorization.authorization!)
+			const authProviderHeaders = await this.oAuth.getToken('ZEEBE')
+			// add arbitraty headers to metadata
+			// See: https://github.com/camunda/camunda-8-js-sdk/issues/448
+			Object.entries(authProviderHeaders).forEach(([key, value]) => {
+				metadata.add(key, value)
+			})
 		}
 		return metadata
 	}


### PR DESCRIPTION
## Description of the change

This pull request enables arbitrary headers on requests by modifying the OAuth token handling in the GrpcClient and updating related provider interfaces and tests.

Refactored token handling in GrpcClient to support multiple headers
Updated IOAuthProvider and BearerAuthProvider to be more generic
Modified documentation and tests to reflect the new behavior

This also reverts the addition of the `setBearerToken` method on the CamundaRestClient, for the more generic and correctly encapsulated injection of an IOAuthProvider.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

