### PR TITLE
feat: add hinting for Rest errors. fixes #456

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,5 @@ dist
 
 docs
 .nx/cache
+
+camunda-support.log*

--- a/src/admin/lib/AdminApiClient.ts
+++ b/src/admin/lib/AdminApiClient.ts
@@ -8,10 +8,10 @@ import {
 	GetCustomCertificateBuffer,
 	GotRetryConfig,
 	RequireConfiguration,
+	beforeCallHook,
 	constructOAuthProvider,
 	createUserAgentString,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	makeBeforeRetryHandlerFor401TokenRetry,
 } from '../../lib'
 import { IOAuthProvider } from '../../oauth'
@@ -53,14 +53,14 @@ export class AdminApiClient {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
 						beforeRetry: [
 							makeBeforeRetryHandlerFor401TokenRetry(
 								this.getHeaders.bind(this)
 							),
 						],
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 						beforeRequest: config.middleware ?? [],
 					},
 				})

--- a/src/c8/lib/CamundaRestClient.ts
+++ b/src/c8/lib/CamundaRestClient.ts
@@ -7,6 +7,7 @@ import { parse, stringify } from 'lossless-json'
 import PCancelable from 'p-cancelable'
 
 import {
+	beforeCallHook,
 	Camunda8ClientConfiguration,
 	CamundaEnvironmentConfigurator,
 	CamundaPlatform8Configuration,
@@ -14,7 +15,6 @@ import {
 	createUserAgentString,
 	GetCustomCertificateBuffer,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	GotRetryConfig,
 	LosslessDto,
 	losslessParse,
@@ -146,14 +146,14 @@ export class CamundaRestClient {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
 						beforeRetry: [
 							makeBeforeRetryHandlerFor401TokenRetry(
 								this.getHeaders.bind(this)
 							),
 						],
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 						beforeRequest: [
 							(options) => {
 								const body = options.body

--- a/src/lib/GotHooks.ts
+++ b/src/lib/GotHooks.ts
@@ -7,6 +7,7 @@ import {
 } from 'got'
 
 import { CamundaSupportLogger } from './CamundaSupportLogger'
+import { CamundaPlatform8Configuration } from './Configuration'
 import { HTTPError } from './GotErrors'
 
 const supportLogger = CamundaSupportLogger.getInstance()
@@ -16,14 +17,13 @@ const supportLogger = CamundaSupportLogger.getInstance()
  * This function stores the call point from the application of got requests.
  * This enables users to see where the error originated from.
  */
-export const gotErrorHandler: HandlerFunction = (options, next) => {
+export const beforeCallHook: HandlerFunction = (options, next) => {
 	if (Object.isFrozen(options.context)) {
 		options.context = { ...options.context, hasRetried: false }
 	}
 	Error.captureStackTrace(options.context)
 	supportLogger.log(`Rest call:`)
 	supportLogger.log(options)
-
 	return next(options)
 }
 
@@ -34,36 +34,56 @@ export const gotErrorHandler: HandlerFunction = (options, next) => {
  * It also logs the error to the Camunda Support log.
  * This is useful for debugging and support purposes.
  */
-export const gotBeforeErrorHook: BeforeErrorHook = (error) => {
-	const { request } = error
-	let detail = ''
-	if (error instanceof GotHTTPError) {
-		error = new HTTPError(error.response)
-		try {
-			const details = JSON.parse(
-				(error.response?.body as string) || '{detail:""}'
-			)
-			;(error as any).statusCode = details.status
-			detail = details ?? ''
-		} catch (e) {
-			;(error as any).statusCode = 0
+export const gotBeforeErrorHook =
+	(config: CamundaPlatform8Configuration): BeforeErrorHook =>
+	(error) => {
+		const { request } = error
+		let detail = ''
+		if (error instanceof GotHTTPError) {
+			error = new HTTPError(error.response)
+			try {
+				const details = JSON.parse(
+					(error.response?.body as string) || '{detail:""}'
+				)
+				;(error as any).statusCode = details.status
+				detail = details ?? ''
+			} catch (e) {
+				;(error as any).statusCode = 0
+			}
 		}
-	}
-	;(error as any).source = (error as any).options.context.stack.split('\n')
-	error.message += ` (request to ${request?.options.url
-		.href}). ${JSON.stringify(detail)}`
-	/** Log details of errors to the Camunda Support log */
-	supportLogger.log('**ERROR**: Got error during Rest call:')
-	supportLogger.log({
-		code: error.code,
-		message: error.message,
-		stack: error.stack,
-		requestOptions: error.request?.options,
-		source: (error as any).source,
-	})
+		;(error as any).source = (error as any).options.context.stack.split('\n')
+		error.message += ` (request to ${request?.options.url
+			.href}). ${JSON.stringify(detail)}`
 
-	return error
-}
+		/** Hinting for error messages. See https://github.com/camunda/camunda-8-js-sdk/issues/456 */
+		/** Here we reason over the error and the configuration to enrich the message with hints */
+		if (error.code === '401') {
+			// the call was unauthorized
+			if (config.CAMUNDA_AUTH_STRATEGY === 'OAUTH') {
+				if (request?.options.headers?.authorization) {
+					/** This is a 401 error, but the token is set in the header */
+					error.message +=
+						' (this may be due to the client credentials not being authorized to access the resource)'
+					if (config.CAMUNDA_TENANT_ID) {
+						/** We're *probably* making a multi-tenant call. It might have been overridden in the call, but we don't have access to the body */
+						error.message += `. Is the client credential authorized in the tenant?`
+					}
+				}
+			}
+		}
+
+		/** Log details of errors to the Camunda Support log */
+		supportLogger.log('**ERROR**: Got error during Rest call:')
+		supportLogger.log({
+			code: error.code,
+			message: error.message,
+			stack: error.stack,
+			requestOptions: error.request?.options,
+			source: (error as any).source,
+		})
+
+		return error
+	}
 
 /**
  *

--- a/src/modeler/lib/ModelerAPIClient.ts
+++ b/src/modeler/lib/ModelerAPIClient.ts
@@ -7,10 +7,10 @@ import {
 	DeepPartial,
 	GetCustomCertificateBuffer,
 	GotRetryConfig,
+	beforeCallHook,
 	constructOAuthProvider,
 	createUserAgentString,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	makeBeforeRetryHandlerFor401TokenRetry,
 } from '../../lib'
 import { IOAuthProvider } from '../../oauth'
@@ -53,14 +53,14 @@ export class ModelerApiClient {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
 						beforeRetry: [
 							makeBeforeRetryHandlerFor401TokenRetry(
 								this.getHeaders.bind(this)
 							),
 						],
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 						beforeRequest: config.middleware ?? [],
 					},
 				})

--- a/src/oauth/lib/CookieAuthProvider.ts
+++ b/src/oauth/lib/CookieAuthProvider.ts
@@ -2,12 +2,12 @@ import { debug } from 'debug'
 import got from 'got'
 
 import {
+	beforeCallHook,
 	CamundaEnvironmentConfigurator,
 	CamundaPlatform8Configuration,
 	DeepPartial,
 	GetCustomCertificateBuffer,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	GotRetryConfig,
 } from '../../lib'
 import { IOAuthProvider } from '../index'
@@ -49,9 +49,9 @@ export class CookieAuthProvider implements IOAuthProvider {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 					},
 				})
 		)

--- a/src/oauth/lib/OAuthProvider.ts
+++ b/src/oauth/lib/OAuthProvider.ts
@@ -9,13 +9,13 @@ import { jwtDecode } from 'jwt-decode'
 
 import { getLogger, Logger } from '../../c8/lib/C8Logger'
 import {
+	beforeCallHook,
 	CamundaEnvironmentConfigurator,
 	CamundaPlatform8Configuration,
 	createUserAgentString,
 	DeepPartial,
 	GetCustomCertificateBuffer,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	GotRetryConfig,
 	RequireConfiguration,
 } from '../../lib'
@@ -128,9 +128,9 @@ export class OAuthProvider implements IOAuthProvider {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 					},
 				})
 		)

--- a/src/operate/lib/OperateApiClient.ts
+++ b/src/operate/lib/OperateApiClient.ts
@@ -8,10 +8,10 @@ import {
 	GetCustomCertificateBuffer,
 	GotRetryConfig,
 	RequireConfiguration,
+	beforeCallHook,
 	constructOAuthProvider,
 	createUserAgentString,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	losslessParse,
 	losslessStringify,
 	makeBeforeRetryHandlerFor401TokenRetry,
@@ -106,14 +106,14 @@ export class OperateApiClient {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
 						beforeRetry: [
 							makeBeforeRetryHandlerFor401TokenRetry(
 								this.getHeaders.bind(this)
 							),
 						],
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 						beforeRequest: config.middleware ?? [],
 					},
 				})

--- a/src/optimize/lib/OptimizeApiClient.ts
+++ b/src/optimize/lib/OptimizeApiClient.ts
@@ -7,10 +7,10 @@ import {
 	GetCustomCertificateBuffer,
 	GotRetryConfig,
 	RequireConfiguration,
+	beforeCallHook,
 	constructOAuthProvider,
 	createUserAgentString,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	makeBeforeRetryHandlerFor401TokenRetry,
 } from '../../lib'
 import { IOAuthProvider } from '../../oauth'
@@ -84,14 +84,14 @@ export class OptimizeApiClient {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
 						beforeRetry: [
 							makeBeforeRetryHandlerFor401TokenRetry(
 								this.getHeaders.bind(this)
 							),
 						],
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 						beforeRequest: config.middleware ?? [],
 					},
 				})

--- a/src/tasklist/lib/TasklistApiClient.ts
+++ b/src/tasklist/lib/TasklistApiClient.ts
@@ -8,10 +8,10 @@ import {
 	GetCustomCertificateBuffer,
 	GotRetryConfig,
 	RequireConfiguration,
+	beforeCallHook,
 	constructOAuthProvider,
 	createUserAgentString,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	losslessParse,
 	losslessStringify,
 	makeBeforeRetryHandlerFor401TokenRetry,
@@ -85,14 +85,14 @@ export class TasklistApiClient {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
 						beforeRetry: [
 							makeBeforeRetryHandlerFor401TokenRetry(
 								this.getHeaders.bind(this)
 							),
 						],
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 						beforeRequest: config.middleware ?? [],
 					},
 				})

--- a/src/zeebe/zb/ZeebeRESTClient.ts
+++ b/src/zeebe/zb/ZeebeRESTClient.ts
@@ -8,10 +8,10 @@ import {
 	GetCustomCertificateBuffer,
 	GotRetryConfig,
 	RequireConfiguration,
+	beforeCallHook,
 	constructOAuthProvider,
 	createUserAgentString,
 	gotBeforeErrorHook,
-	gotErrorHandler,
 	makeBeforeRetryHandlerFor401TokenRetry,
 } from '../../lib'
 import { IOAuthProvider } from '../../oauth'
@@ -71,14 +71,14 @@ export class ZeebeRestClient {
 					https: {
 						certificateAuthority,
 					},
-					handlers: [gotErrorHandler],
+					handlers: [beforeCallHook],
 					hooks: {
 						beforeRetry: [
 							makeBeforeRetryHandlerFor401TokenRetry(
 								this.getHeaders.bind(this)
 							),
 						],
-						beforeError: [gotBeforeErrorHook],
+						beforeError: [gotBeforeErrorHook(config)],
 					},
 				})
 		)


### PR DESCRIPTION
## Description of the change

This PR adds hinting for REST errors by updating error handling hooks across multiple API client modules.

Replaces gotErrorHandler with beforeCallHook to capture call context.
Updates beforeError hooks to pass the configuration object to gotBeforeErrorHook for enriched error messages.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

