### PR TITLE
refactor: replace `neon-env` with `typed-env`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,12 @@
 				"lodash.mergewith": "^4.6.2",
 				"long": "^4.0.0",
 				"lossless-json": "^4.0.1",
-				"neon-env": "^0.1.3",
 				"p-cancelable": "^2.1.1",
 				"promise-retry": "^1.1.1",
 				"reflect-metadata": "^0.2.1",
 				"stack-trace": "0.0.10",
 				"typed-duration": "^1.0.12",
+				"typed-env": "^2.0.0",
 				"uuid": "^7.0.3",
 				"winston": "^3.14.2"
 			},
@@ -12527,14 +12527,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/neon-env": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/neon-env/-/neon-env-0.1.3.tgz",
-			"integrity": "sha512-Zo+L6Nm19gJrjyfhxn/ZDm8eIIDzr75o64ZhijBau4LNuhLzjEAteRg3gchIvgaN8XTo5BxN6iTNP5clZQ0agA==",
-			"engines": {
-				"node": "^14.18 || >=16.0.0"
-			}
-		},
 		"node_modules/nerf-dart": {
 			"version": "1.0.0",
 			"dev": true,
@@ -18502,6 +18494,15 @@
 			"license": "MIT",
 			"optionalDependencies": {
 				"rxjs": "*"
+			}
+		},
+		"node_modules/typed-env": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/typed-env/-/typed-env-2.0.0.tgz",
+			"integrity": "sha512-9nP+7+pctDlpFNKS4nkXPVkCOdAj7Ax8QeHhQkQ0hEGzsJ5ClgfhjwGN89q6s/EukHqyq9rDRzZ2yctCIEJGxA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
 			}
 		},
 		"node_modules/typedarray": {

--- a/package.json
+++ b/package.json
@@ -165,12 +165,12 @@
 		"lodash.mergewith": "^4.6.2",
 		"long": "^4.0.0",
 		"lossless-json": "^4.0.1",
-		"neon-env": "^0.1.3",
 		"p-cancelable": "^2.1.1",
 		"promise-retry": "^1.1.1",
 		"reflect-metadata": "^0.2.1",
 		"stack-trace": "0.0.10",
 		"typed-duration": "^1.0.12",
+		"typed-env": "^2.0.0",
 		"uuid": "^7.0.3",
 		"winston": "^3.14.2"
 	}

--- a/src/lib/Configuration.ts
+++ b/src/lib/Configuration.ts
@@ -1,7 +1,7 @@
 import debug from 'debug'
 import { BeforeRequestHook } from 'got'
 import mergeWith from 'lodash.mergewith'
-import { createEnv } from 'neon-env'
+import { createEnv } from 'typed-env'
 
 import { Logger } from '../c8/lib/C8Logger'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
## Description of the change

Thanks for using `neon-env`! I'm a maintainer of the package, and today `neon-env` [was moved over](https://github.com/SuperchupuDev/neon-env/releases/tag/0.2.3) to `typed-env`, and the former was deprecated. `neon-env` started out being a maintained fork of `typed-env`, and now the maintainers of both packages agreed to merge it into `typed-env` and resume any further development there.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

(None? (refactor))

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

In theory there are no further code changes needed, as `typed-env@2.0.0` shares the same code as the latest version of `neon-env`. Although `@camunda8/sdk` uses an old version of `neon-env`, it should be fine as there are no significant breaking changes affecting the upgrade here