### PR TITLE
Fix: Check for an Existing correlationKey Before Generating a New UUID

### DIFF
--- a/src/zeebe/zb/ZeebeGrpcClient.ts
+++ b/src/zeebe/zb/ZeebeGrpcClient.ts
@@ -1061,8 +1061,9 @@ export class ZeebeGrpcClient extends TypedEmitter<
 		 * See: https://github.com/zeebe-io/zeebe/issues/1012 and https://github.com/zeebe-io/zeebe/issues/1022
 		 */
 
+		const correlationKey = publishStartMessageRequest.correlationKey ?? uuid()
 		const publishMessageRequest: Grpc.PublishMessageRequest = {
-			correlationKey: uuid(),
+			correlationKey,
 			...publishStartMessageRequest,
 			tenantId: publishStartMessageRequest.tenantId ?? this.tenantId,
 		}


### PR DESCRIPTION
## Description of the change

check the existing correlationKey first instead of using uuid() every time

## Type of change

-  Bug fix


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


