### PR TITLE
Alpha

### DIFF
--- a/src/zeebe/lib/ZBWorkerBase.ts
+++ b/src/zeebe/lib/ZBWorkerBase.ts
@@ -468,11 +468,13 @@ You should call only one job action method in the worker handler. This is a bug 
 	}
 
 	private handleStreamEnd = (id) => {
-		this.jobStream?.removeAllListeners()
+		// We do not delete the stream listeners, as the error event can be emitted asynchronously by a connection error after end
+		// for example - due to broker overload
+		// If the 'error' event has no listener, an uncaught exception that crashes the application will be thrown.
+		// The job stream will be garbage collected, and the listeners will be removed. There is no need to remove them manually.
+		// See: https://github.com/camunda/camunda-8-js-sdk/issues/466
 		this.jobStream = undefined
-		this.logger.logDebug(
-			`Deleted job stream [${id}] listeners and job stream reference`
-		)
+		this.logger.logDebug(`Deleted job stream [${id}] reference`)
 	}
 
 	private async poll() {

--- a/src/zeebe/zb/ZeebeGrpcClient.ts
+++ b/src/zeebe/zb/ZeebeGrpcClient.ts
@@ -1061,8 +1061,9 @@ export class ZeebeGrpcClient extends TypedEmitter<
 		 * See: https://github.com/zeebe-io/zeebe/issues/1012 and https://github.com/zeebe-io/zeebe/issues/1022
 		 */
 
+		const correlationKey = publishStartMessageRequest.correlationKey ?? uuid()
 		const publishMessageRequest: Grpc.PublishMessageRequest = {
-			correlationKey: uuid(),
+			correlationKey,
 			...publishStartMessageRequest,
 			tenantId: publishStartMessageRequest.tenantId ?? this.tenantId,
 		}


### PR DESCRIPTION
## Description of the change

This PR updates the correlation key assignment in the publish message request, allowing the use of an existing correlation key from the request if provided, and generating a new UUID only as a fallback.

Updates the correlation key assignment logic in the ZeebeGrpcClient.
Improves the request object construction by reusing an existing key when available.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

