### PR TITLE
Fix-4move 

### DIFF
--- a/src/c8/lib/CamundaJobWorker.ts
+++ b/src/c8/lib/CamundaJobWorker.ts
@@ -228,6 +228,11 @@ export class CamundaJobWorker<
 				this.backoffRetryCount = 0
 			})
 			.catch((e) => {
+				// If the poll was cancelled because the worker is stopping, we don't need to log an error — the canceled promise rejection is expected.
+				// https://github.com/camunda/camunda-8-js-sdk/issues/432
+				if (this.stopping && e.code === 'ERR_CANCELED') {
+					return
+				}
 				// This can throw a 400, 401, or 500 REST Error with the Content-Type application/problem+json
 				// The schema is:
 				// { type: string, title: string, status: number, detail: string, instance: string }


### PR DESCRIPTION
## Description of the change

Suppress error logging for the cancelation of the active poll when the REST job worker is closing.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

