### PR TITLE
Feat-clear-auth-cache

### DIFF
--- a/src/__tests__/oauth/OAuthProvider.unit.spec.ts
+++ b/src/__tests__/oauth/OAuthProvider.unit.spec.ts
@@ -41,14 +41,14 @@ afterAll(() => {
 	EnvironmentSetup.restoreEnv(storedEnvironment)
 })
 
-function removeCacheDir(dirpath: string) {
-	if (fs.existsSync(dirpath)) {
-		fs.rmSync(dirpath, {
-			recursive: true,
-			force: true,
-		})
-	}
-}
+// function removeCacheDir(dirpath: string) {
+// 	if (fs.existsSync(dirpath)) {
+// 		fs.rmSync(dirpath, {
+// 			recursive: true,
+// 			force: true,
+// 		})
+// 	}
+// }
 
 describe('OAuthProvider', () => {
 	it('Throws in the constructor if there in no clientId credentials', () => {
@@ -117,10 +117,10 @@ describe('OAuthProvider', () => {
 
 	it('Gets the token cache dir from the environment', () => {
 		const tokenCacheDir = path.join(__dirname, '.token-cache')
-		removeCacheDir(tokenCacheDir)
-		expect(fs.existsSync(tokenCacheDir)).toBe(false)
 		process.env.CAMUNDA_TOKEN_CACHE_DIR = tokenCacheDir
 		const { OAuthProvider } = require('../../oauth')
+		OAuthProvider.clearCacheDir(tokenCacheDir)
+		expect(fs.existsSync(tokenCacheDir)).toBe(false)
 
 		const o = new OAuthProvider({
 			config: {
@@ -133,7 +133,7 @@ describe('OAuthProvider', () => {
 		expect(o).toBeTruthy()
 		const exists = fs.existsSync(tokenCacheDir)
 		expect(exists).toBe(true)
-		removeCacheDir(tokenCacheDir)
+		OAuthProvider.clearCacheDir(tokenCacheDir)
 
 		expect(fs.existsSync(tokenCacheDir)).toBe(false)
 	})
@@ -142,8 +142,7 @@ describe('OAuthProvider', () => {
 		const tokenCacheDir = path.join(__dirname, '.token-cache')
 		process.env.CAMUNDA_TOKEN_CACHE_DIR = tokenCacheDir
 		const { OAuthProvider } = require('../../oauth')
-		removeCacheDir(tokenCacheDir)
-
+		OAuthProvider.clearCacheDir(tokenCacheDir)
 		expect(fs.existsSync(tokenCacheDir)).toBe(false)
 
 		const o = new OAuthProvider({
@@ -157,7 +156,7 @@ describe('OAuthProvider', () => {
 
 		expect(o).toBeTruthy()
 		expect(fs.existsSync(tokenCacheDir)).toBe(true)
-		removeCacheDir(tokenCacheDir)
+		OAuthProvider.clearCacheDir(tokenCacheDir)
 
 		expect(fs.existsSync(tokenCacheDir)).toBe(false)
 	})
@@ -166,7 +165,7 @@ describe('OAuthProvider', () => {
 		const tokenCacheDir = path.join(__dirname, '.token-cache')
 		process.env.CAMUNDA_TOKEN_CACHE_DIR = tokenCacheDir
 		const { OAuthProvider } = require('../../oauth')
-		removeCacheDir(tokenCacheDir)
+		OAuthProvider.clearCacheDir(tokenCacheDir)
 
 		expect(fs.existsSync(tokenCacheDir)).toBe(false)
 		if (os.platform() === 'win32') {
@@ -203,7 +202,7 @@ describe('OAuthProvider', () => {
 		if (os.platform() === 'win32') {
 			execSync(`icacls ${tokenCacheDir} /grant Everyone:(OI)(CI)(F)`)
 		}
-		removeCacheDir(tokenCacheDir)
+		OAuthProvider.clearCacheDir(tokenCacheDir)
 		expect(thrown).toBe(true)
 		expect(fs.existsSync(tokenCacheDir)).toBe(false)
 	})

--- a/src/oauth/lib/OAuthProvider.ts
+++ b/src/oauth/lib/OAuthProvider.ts
@@ -74,6 +74,20 @@ export class OAuthProvider implements IHeadersProvider {
 	private rest: Promise<typeof got>
 	private log: Logger
 
+	/**
+	 *
+	 * @param dir Optional directory to clear the cache from. If not provided, the default cache directory is used.
+	 * @description Clears the OAuth token cache directory. This will remove all cached tokens from the specified directory.
+	 */
+	public static clearCacheDir(dir?: string) {
+		const cacheDir = dir ?? OAuthProvider.defaultTokenCache
+		if (fs.existsSync(cacheDir)) {
+			fs.rmSync(cacheDir, {
+				recursive: true,
+				force: true,
+			})
+		}
+	}
 	constructor(options?: {
 		config?: DeepPartial<CamundaPlatform8Configuration>
 	}) {


### PR DESCRIPTION
## Description of the change

Add static method to OAuthProvider to clear token file cache.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have opened this pull request against the `alpha` branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

