### PR TITLE
fix: prevent ZBLogger crash when stacktrace is undefined

### DIFF
--- a/src/lib/Configuration.ts
+++ b/src/lib/Configuration.ts
@@ -345,7 +345,7 @@ const zeebeEnv = createEnv({
 	ZEEBE_CLIENT_LOG_LEVEL: {
 		type: 'string',
 		optional: true,
-		choices: ['DEBUG', 'INFO', 'NONE'],
+		choices: ['DEBUG', 'INFO', 'ERROR', 'NONE'],
 		default: 'INFO',
 	},
 	/** Immediately connect to the Zeebe Gateway (issues a silent topology request). Defaults to false */

--- a/src/zeebe/lib/ZBLogger.ts
+++ b/src/zeebe/lib/ZBLogger.ts
@@ -118,7 +118,7 @@ export class ZBLogger {
 		const context = makeUsefulStacktrace()
 		const msg: Msg = {
 			timestamp: new Date(),
-			context, //`${frame.getFileName()}:${frame.getLineNumber()}`,
+			context,
 			level,
 			message,
 			time: dayjs().format('YYYY MMM-DD HH:mm:ssA'),
@@ -158,19 +158,23 @@ export class ZBLogger {
 
 function makeUsefulStacktrace(): string {
 	const frame = stackTrace.get()
+	/**
+	 * In here, everything uses optional chaining, because we do not want the logger to crash
+	 * if the stack trace is not available for some reason.
+	 */
 	return JSON.stringify(
 		frame
 			.filter((callsite) => {
+				const callsiteFileName = callsite?.getFileName?.() ?? ''
 				const shouldInclude = !(
-					callsite.getFileName().includes('ZBLogger') ||
-					callsite.getFileName().includes('StatefulLogInterceptor')
+					callsiteFileName.includes('ZBLogger') ||
+					callsiteFileName.includes('StatefulLogInterceptor')
 				)
-				// console.log(callsite.getFileName(), shouldInclude)
 				return shouldInclude
 			})
 			.map(
 				(callsite) =>
-					`${callsite.getFileName()}:${callsite.getLineNumber()} ${callsite.getFunctionName()}`
+					`${callsite?.getFileName?.()}:${callsite?.getLineNumber?.()} ${callsite?.getFunctionName?.()}`
 			)
 	)
 }


### PR DESCRIPTION
## Description of the change

Prevent ZBLogger crash when stacktrace is undefined

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

