### PR TITLE
feat: backoff retry on 429 "Too many client requests". FIxes #528

### DIFF
--- a/src/__tests__/zeebe/integration-rest/UserTask-rest.spec.ts
+++ b/src/__tests__/zeebe/integration-rest/UserTask-rest.spec.ts
@@ -1,3 +1,4 @@
+import { PollingOperation } from '../../../'
 import { TasklistApiClient } from '../../../tasklist'
 import { ZeebeGrpcClient, ZeebeRestClient } from '../../../zeebe'
 
@@ -14,12 +15,16 @@ test('can update a task', async () => {
 		variables: {},
 	})
 	const tasklist = new TasklistApiClient()
-	await new Promise((resolve) => setTimeout(resolve, 10000))
-	const tasks = await tasklist.searchTasks({
-		state: 'CREATED',
+	const tasks = await PollingOperation({
+		operation: () =>
+			tasklist.searchTasks({
+				state: 'CREATED',
+			}),
+		predicate: (tasks) => tasks.length > 0,
+		interval: 100,
+		timeout: 10000,
 	})
 	const zbc = new ZeebeRestClient()
-	await new Promise((resolve) => setTimeout(resolve, 1000))
 	const res = await zbc.completeUserTask({
 		userTaskKey: tasks[0].id,
 	})

--- a/src/lib/GotHooks.ts
+++ b/src/lib/GotHooks.ts
@@ -122,5 +122,5 @@ export const makeBeforeRetryHandlerFor401TokenRetry =
 export const GotRetryConfig = {
 	limit: 1,
 	methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as Method[],
-	statusCodes: [401],
+	statusCodes: [401, 429],
 }


### PR DESCRIPTION
## Description of the change

Implement backoff retry on HTTP status code 429 "Too many requests" for the Rest APIs.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
