### PR TITLE
Fix-545

### DIFF
--- a/src/__tests__/8.8/getDecisionInstance.spec.ts
+++ b/src/__tests__/8.8/getDecisionInstance.spec.ts
@@ -65,13 +65,53 @@ describe('CamundaRestClient.getDecisionInstance', () => {
 		expect(result.decisionDefinitionId).toBe(decisionDefId)
 		expect(result.decisionDefinitionName).toBe('Dish Decision')
 		expect(result.decisionDefinitionVersion).toBeDefined()
-		expect(result.decisionDefinitionType).toBeDefined()
+		expect(result.decisionDefinitionType).toBe('DECISION_TABLE')
 		expect(result.processInstanceKey).toBeDefined() // May be null/undefined if not called from a process
+		expect(result.processDefinitionKey).toBeDefined() // May be -1 if not called from a process
 		expect(result.evaluationDate).toBeDefined()
 		expect(result.state).toBe('EVALUATED')
 		expect(result.result).toBeDefined()
 		expect(JSON.parse(result.result)).toBe('Light Salad and a nice Steak')
-		expect(result.decisionDefinitionType).toBe('DECISION_TABLE')
+
+		// Assertions for evaluatedInputs
+		expect(result.evaluatedInputs).toBeDefined()
+		expect(Array.isArray(result.evaluatedInputs)).toBe(true)
+		expect(result.evaluatedInputs.length).toBeGreaterThan(0)
+
+		// Validate first input (Season)
+		const seasonInput = result.evaluatedInputs.find(
+			(input) => input.inputId === 'Input_1'
+		)
+		expect(seasonInput).toBeDefined()
+		expect(seasonInput?.inputName).toBe('Season')
+		expect(seasonInput?.inputValue).toBe('"Summer"')
+
+		// Validate second input (Guest Count)
+		const guestCountInput = result.evaluatedInputs.find(
+			(input) => input.inputId === 'InputClause_0tymfo2'
+		)
+		expect(guestCountInput).toBeDefined()
+		expect(guestCountInput?.inputName).toBe('Guest Count')
+		expect(guestCountInput?.inputValue).toBe('5')
+
+		// Assertions for matchedRules
+		expect(result.matchedRules).toBeDefined()
+		expect(Array.isArray(result.matchedRules)).toBe(true)
+		expect(result.matchedRules.length).toBeGreaterThan(0)
+
+		// Validate matched rule
+		const matchedRule = result.matchedRules[0]
+		expect(matchedRule.ruleId).toBe('DecisionRule_09z3x97')
+		expect(matchedRule.ruleIndex).toBeDefined()
+		expect(matchedRule.evaluatedOutputs).toBeDefined()
+		expect(Array.isArray(matchedRule.evaluatedOutputs)).toBe(true)
+		expect(matchedRule.evaluatedOutputs.length).toBeGreaterThan(0)
+
+		// Validate output
+		const output = matchedRule.evaluatedOutputs[0]
+		expect(output.outputId).toBe('Output_1')
+		expect(output.outputName).toBe('Dish')
+		expect(output.outputValue).toBe('"Light Salad and a nice Steak"')
 	})
 
 	it('should handle a non-existent decision instance', async () => {

--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -1468,7 +1468,7 @@ export interface CamundaRestSearchDecisionInstancesResponse
  * Response from getting a single decision instance by its key.
  */
 export interface GetDecisionInstanceResponse {
-	/** The decision instance key. */
+	/** The decision instance key. Note that this is not the unique identifier of the entity itself; the decisionInstanceId serves as the primary identifier. */
 	decisionInstanceKey: string
 	/** The decision definition ID. */
 	decisionDefinitionId: string
@@ -1498,4 +1498,27 @@ export interface GetDecisionInstanceResponse {
 		| 'UNKNOWN'
 	/** The result of the decision evaluation. */
 	result: string
+	/** The evaluated inputs of the decision instance. */
+	evaluatedInputs: Array<{
+		/** The ID of the evaluated decision input. */
+		inputId: string
+		/** The name of the evaluated decision input. */
+		inputName: string
+		/** The value of the evaluated decision input. */
+		inputValue: string
+	}>
+	matchedRules: Array<{
+		/** The ID of the matched rule. */
+		ruleId: string
+		/** The index of the matched rule. */
+		ruleIndex: number
+		evaluatedOutputs: Array<{
+			/** The ID of the evaluated decision output. */
+			outputId: string
+			/** The name of the evaluated decision output. */
+			outputName: string
+			/** The value of the evaluated decision output. */
+			outputValue: string
+		}>
+	}>
 }


### PR DESCRIPTION
## Description of the change

Add missing Dto fields to getDecisionInstanceResponse

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
