### PR TITLE
fix(docs): adjust variable names for cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ To use cookie auth, set the following value:
 CAMUNDA_AUTH_STRATEGY=COOKIE
 
 # Optional configurable values - these are the defaults
-CAMUNDA_AUTH_COOKIE_URL=http://localhost:8080/api/login
-CAMUNDA_AUTH_COOKIE_USERNAME=demo
-CAMUNDA_AUTH_COOKIE_PASSWORD=demo
+CAMUNDA_COOKIE_AUTH_URL=http://localhost:8080/api/login
+CAMUNDA_COOKIE_AUTH_USERNAME=demo
+CAMUNDA_COOKIE_AUTH_PASSWORD=demo
 ```
 
 ### Bearer Token Auth


### PR DESCRIPTION
## Description of the change

Use the right names for configuration variables for COOKIE auth in README. cf. implementation in https://github.com/camunda/camunda-8-js-sdk/blob/main/src/oauth/lib/CookieAuthProvider.ts#L41. This seems to be the only place where it is wrong, but in the forum its also wrong: https://forum.camunda.io/t/js-sdk-authentication-for-c8run/61295

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have read the `CONTRIBUTING` doc
- [x] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

[If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]
