### PR TITLE
Revert job.fail regression

### DIFF
--- a/src/__tests__/oauth/OAuthProvider-integration.spec.ts
+++ b/src/__tests__/oauth/OAuthProvider-integration.spec.ts
@@ -27,16 +27,10 @@ test.runIf(
 		},
 	})
 	const now = new Date()
-	try {
-		await o1.getHeaders('ZEEBE')
-	} catch (e) {
-		console.log(e)
-	}
-	try {
-		await o1.getHeaders('ZEEBE')
-	} catch (e) {
-		console.log(e)
-	}
+
+	await o1.getHeaders('ZEEBE').catch((e) => e)
+	await o1.getHeaders('ZEEBE').catch((e) => e)
+
 	const elapsed = new Date().getTime() - now.getTime()
 	expect(elapsed).toBeLessThan(2000) // Less than 2s means no tarpit delay
 })

--- a/src/__tests__/zeebe/integration/Worker-LongPoll.spec.ts
+++ b/src/__tests__/zeebe/integration/Worker-LongPoll.spec.ts
@@ -6,13 +6,13 @@ import { cancelProcesses } from '../../../zeebe/lib/cancelProcesses'
 
 vi.setConfig({ testTimeout: 40_000 })
 
-let processId: string
+let processDefinitionKey: string
 
 let zbcLongPoll: ZeebeGrpcClient
 
 afterAll(async () => {
 	await zbcLongPoll.close()
-	await cancelProcesses(processId)
+	await cancelProcesses(processDefinitionKey)
 })
 
 beforeAll(async () => {
@@ -22,8 +22,8 @@ beforeAll(async () => {
 	const res = await zbcLongPoll.deployResource({
 		processFilename: './src/__tests__/testdata/Worker-LongPoll.bpmn',
 	})
-	processId = res.deployments[0].process.processDefinitionKey
-	await cancelProcesses(processId)
+	processDefinitionKey = res.deployments[0].process.processDefinitionKey
+	await cancelProcesses(processDefinitionKey)
 })
 
 test.runIf(allowAny([{ deployment: 'saas' }, { deployment: 'self-managed' }]))(

--- a/src/c8/lib/CamundaJobWorker.ts
+++ b/src/c8/lib/CamundaJobWorker.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events'
-import util from 'util'
 
 import PCancelable from 'p-cancelable'
 import TypedEmitter from 'typed-emitter'
@@ -243,7 +242,7 @@ export class CamundaJobWorker<
 				this.log.debug(`Activated ${count} jobs`, this.logMeta())
 				this.emit('work', jobs)
 				// The job handlers for the activated jobs will run in parallel
-				jobs.forEach(this.handleJob.bind(this)) // if the handler throws, the job will be failed and the error logged
+				jobs.forEach((job) => this.handleJob(job)) // if the handler throws, the job will be failed and the error logged
 				this.pollLock = false
 				this.backoffRetryCount = 0
 			})
@@ -264,13 +263,8 @@ export class CamundaJobWorker<
 						'The server responded with a back pressure signal. Check the server resource allocation and current load.'
 					)
 				} else {
-					const formattedError = util.inspect(e, {
-						depth: 10, // Increase depth if needed
-						colors: false,
-						customInspect: true,
-					})
 					this.log.error('Error during job worker poll')
-					this.log.error(formattedError)
+					this.log.error(e)
 				}
 				this.emit('pollError', e)
 				this.activePoll = undefined

--- a/src/c8/lib/CamundaRestClient.ts
+++ b/src/c8/lib/CamundaRestClient.ts
@@ -1664,7 +1664,7 @@ const streams: ReadStream[] = uploadedFiles.map((file) => {
 	 * @param job The job to add the methods to
 	 * @returns The job with the added methods
 	 */
-	private addJobMethods = <Variables, CustomHeaders>(
+	private readonly addJobMethods = <Variables, CustomHeaders>(
 		job: RestJob<Variables, CustomHeaders>
 	): ActivatedJob<Variables, CustomHeaders> => {
 		return {


### PR DESCRIPTION
## Description of the change

Reverts a breaking change regression to job.fail in the CamundaRest Client.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

