### PR TITLE
fix: update OCA client dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "8.6.13",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@camunda8/orchestration-cluster-api": "^1.1.5",
+				"@camunda8/orchestration-cluster-api": "^1.2.1",
 				"@grpc/grpc-js": "1.12.5",
 				"@grpc/proto-loader": "0.7.13",
 				"@types/form-data": "^2.2.1",
@@ -118,9 +118,9 @@
 			}
 		},
 		"node_modules/@camunda8/orchestration-cluster-api": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-1.1.5.tgz",
-			"integrity": "sha512-/3uBP6iJ/nBLHPaETElFqBRnxWnjJ8P5+fzZf2f/lGnvtyaSG+7wrJk+4STKpsKs1pfChR8WOnIkKIOmuWfxaw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-1.2.1.tgz",
+			"integrity": "sha512-d3iQn7P1aLShBB/4UfqMM1OXjynXAtSpj3jFY0hC3thO8bwapQYs4A9vwys/HxINla/RpeyNTtY9yvLD7nzsNw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"p-retry": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
 		"win-ca": "3.5.1"
 	},
 	"dependencies": {
-		"@camunda8/orchestration-cluster-api": "^1.1.5",
+		"@camunda8/orchestration-cluster-api": "^1.2.1",
 		"@grpc/grpc-js": "1.12.5",
 		"@grpc/proto-loader": "0.7.13",
 		"@types/form-data": "^2.2.1",

--- a/src/zeebe/lib/cancelProcesses.ts
+++ b/src/zeebe/lib/cancelProcesses.ts
@@ -6,18 +6,18 @@ const camunda = new Camunda8().getCamundaRestClient()
 const topology = camunda.getTopology()
 
 export async function cancelProcesses(processDefinitionKey: string) {
-	const { searchProcessInstances, cancelProcessInstance } = (
-		await topology
-	).gatewayVersion.includes('8.8')
-		? {
-				searchProcessInstances: camunda.searchProcessInstances.bind(camunda),
-				cancelProcessInstance: (pid) =>
-					camunda.cancelProcessInstance({ processInstanceKey: pid }),
-			}
-		: {
-				searchProcessInstances: operate.searchProcessInstances.bind(operate),
-				cancelProcessInstance: operate.deleteProcessInstance.bind(operate),
-			}
+	const serverVersion = (await topology).gatewayVersion
+	const { searchProcessInstances, cancelProcessInstance } =
+		serverVersion.includes('8.8') || serverVersion.includes('8.9')
+			? {
+					searchProcessInstances: camunda.searchProcessInstances.bind(camunda),
+					cancelProcessInstance: (pid) =>
+						camunda.cancelProcessInstance({ processInstanceKey: pid }),
+				}
+			: {
+					searchProcessInstances: operate.searchProcessInstances.bind(operate),
+					cancelProcessInstance: operate.deleteProcessInstance.bind(operate),
+				}
 
 	const processes = await searchProcessInstances({
 		filter: {


### PR DESCRIPTION
## Description of the change

Update OCA client to add `job.error` method in worker.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have opened this pull request against the `alpha` branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
