### PR TITLE
fix: keep error.message static for error-monitoring grouping

### DIFF
--- a/src/lib/GotErrors.ts
+++ b/src/lib/GotErrors.ts
@@ -57,6 +57,23 @@ export class HTTPError extends Got.HTTPError implements CamundaRestError {
 			this.message += ` - ${response.body}`
 		}
 	}
+
+	/**
+	 * Provides a rich string representation including method, URL, and response
+	 * detail for debugging (e.g. console.log, uncaught exception traces) while
+	 * keeping error.message static for error-monitoring grouping (Sentry, etc.).
+	 * See: https://github.com/camunda/camunda-8-js-sdk/issues/658
+	 */
+	toString(): string {
+		const parts = [this.message]
+		if (this.method || this.url) {
+			parts.push(`(${this.method ?? ''} ${this.url ?? ''})`)
+		}
+		if (this.detail) {
+			parts.push(this.detail)
+		}
+		return parts.join(' ')
+	}
 }
 
 export type RestError =
@@ -107,7 +124,18 @@ export const gotBeforeErrorHook =
 
 		const enhancedStack = error.options.context.stack?.split('\n')
 		error.source = enhancedStack ?? ['No enhanced stack trace available']
-		error.message += ` (${method} ${url}). ${JSON.stringify(detail)}`
+
+		// Attach request context as structured properties so error-monitoring
+		// tools (Sentry, Datadog, etc.) can group by the static error.message.
+		// See: https://github.com/camunda/camunda-8-js-sdk/issues/658
+		if (!(error instanceof HTTPError)) {
+			// HTTPError already has these from its constructor; for plain
+			// RequestErrors we attach them here.
+			;(error as RequestError & { method?: string }).method = method
+			;(error as RequestError & { url?: string }).url = url
+			;(error as RequestError & { detail?: string }).detail =
+				typeof detail === 'string' ? detail : JSON.stringify(detail)
+		}
 		if (enhancedStack) {
 			error.message += `. Enhanced stack trace available as error.source.`
 		}
@@ -168,6 +196,9 @@ export const gotBeforeErrorHook =
 		supportLogger.log({
 			code: error.code,
 			message: error.message,
+			method,
+			url,
+			detail,
 			stack: error.stack, // replaced stack
 			originalStack: (error as RequestError & { originalStack?: string })
 				.originalStack,


### PR DESCRIPTION
## Description of the change

`gotBeforeErrorHook` appended HTTP method, full URL, and JSON response body into `error.message`, making every error unique. Error-monitoring tools (Sentry, Datadog, etc.) use `error.message` as a primary grouping key, so each occurrence created a separate issue instead of grouping together.

### Before

```
error.message = "Response code 404 (Not Found) (POST https://api.example.com/v2/process-instances/search). {"type":"about:blank","title":"Not Found",...}"\
```

### After

```
error.message = "Response code 404 (Not Found) - {response body}"
```

The dynamic request context is available as structured properties:
- `error.method` — HTTP method (e.g. `POST`)
- `error.url` — full request URL
- `error.detail` — response detail string
- `error.statusCode` — numeric status code
- `error.title` — error title from response
- `error.response.body` — full response body

A `toString()` override on `HTTPError` provides rich output for `console.log()` and uncaught exception traces, preserving the current debugging experience.

### Impact

All HTTP clients are affected (CamundaRestClient, Operate, Optimize, Tasklist, Modeler, Admin, OAuth). Code using structured error properties (`error.statusCode`, `error.detail`, etc.) is unaffected. Code pattern-matching on `error.message` content may need updating.

Fixes #658

## Type of change

- [x] Bug fix

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] TypeScript compiles with zero errors
- [x] Unit test results identical to main (pre-existing integration test failures only)