### PR TITLE
ci: backport Dependabot CI fixes to stable/8.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
     schedule:
       interval: weekly
     target-branch: alpha
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "stable/8.8"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: "stable/8.8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         run: npm run test
 
   local_integration:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment:
       name: selfhosted
@@ -75,6 +76,7 @@ jobs:
         run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose-modeler.yaml down
 
   local_multitenancy_integration:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment:
       name: selfhosted
@@ -123,6 +125,7 @@ jobs:
         run: docker compose -f docker/docker-compose-multitenancy.yaml -f docker/docker-compose-modeler.yaml down
 
   saas_integration:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment: integration
     steps:
@@ -158,6 +161,7 @@ jobs:
           CAMUNDA_CONSOLE_OAUTH_AUDIENCE: ${{ vars.CAMUNDA_CONSOLE_OAUTH_AUDIENCE}}
 
   saas_integration_8_8:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment: integration-8.8
     steps:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -28,6 +28,7 @@ jobs:
         run: npm run lint
 
       - name: Commit and push if changes
+        if: github.actor != 'dependabot[bot]'
         run: |
           git config --global user.name 'GitHub Action'
           git config --global user.email 'josh.wulf@camunda.com'


### PR DESCRIPTION
Cherry-picks two commits from `main` to fix Dependabot PRs failing CI on `stable/8.8`:\n\n- Skip the \"Commit and push\" step in `commitlint.yml` for Dependabot (read-only token)\n- Skip environment-gated CI jobs for Dependabot PRs (avoids admin approval + sequential run blocking)\n- Add Dependabot config for `stable/8.8` branch