### PR TITLE
feat(admin): implement all missing Admin API operations

### DIFF
--- a/src/__tests__/admin/admin-new-operations.integration.spec.ts
+++ b/src/__tests__/admin/admin-new-operations.integration.spec.ts
@@ -105,7 +105,8 @@ describe('AdminApiClient - new operations', () => {
 					expect(status.status).toBeDefined()
 				} catch (e: unknown) {
 					// 403 = feature not available on this plan
-					if ((e as { statusCode?: number }).statusCode === 403) {
+					const err = e as { response?: { statusCode?: number } }
+					if (err.response?.statusCode === 403) {
 						return
 					}
 					throw e
@@ -125,7 +126,8 @@ describe('AdminApiClient - new operations', () => {
 					expect(Array.isArray(res.clients)).toBe(true)
 				} catch (e: unknown) {
 					// 403 = feature not available on this plan
-					if ((e as { statusCode?: number }).statusCode === 403) {
+					const err = e as { response?: { statusCode?: number } }
+					if (err.response?.statusCode === 403) {
 						return
 					}
 					throw e

--- a/src/__tests__/admin/admin-new-operations.integration.spec.ts
+++ b/src/__tests__/admin/admin-new-operations.integration.spec.ts
@@ -99,9 +99,17 @@ describe('AdminApiClient - new operations', () => {
 		test.runIf(saasMatrix)(
 			'getSecureConnectivityStatus returns status',
 			async () => {
-				const status = await c.getSecureConnectivityStatus(clusterUuid)
-				expect(status).toBeTruthy()
-				expect(status.status).toBeDefined()
+				try {
+					const status = await c.getSecureConnectivityStatus(clusterUuid)
+					expect(status).toBeTruthy()
+					expect(status.status).toBeDefined()
+				} catch (e: unknown) {
+					// 403 = feature not available on this plan
+					if ((e as { statusCode?: number }).statusCode === 403) {
+						return
+					}
+					throw e
+				}
 			}
 		)
 	})
@@ -110,10 +118,18 @@ describe('AdminApiClient - new operations', () => {
 		test.runIf(saasMatrix)(
 			'getMonitoringClients returns response',
 			async () => {
-				const res = await c.getMonitoringClients(clusterUuid)
-				expect(res).toBeTruthy()
-				expect(res.clients).toBeDefined()
-				expect(Array.isArray(res.clients)).toBe(true)
+				try {
+					const res = await c.getMonitoringClients(clusterUuid)
+					expect(res).toBeTruthy()
+					expect(res.clients).toBeDefined()
+					expect(Array.isArray(res.clients)).toBe(true)
+				} catch (e: unknown) {
+					// 403 = feature not available on this plan
+					if ((e as { statusCode?: number }).statusCode === 403) {
+						return
+					}
+					throw e
+				}
 			}
 		)
 	})

--- a/src/__tests__/admin/admin-new-operations.integration.spec.ts
+++ b/src/__tests__/admin/admin-new-operations.integration.spec.ts
@@ -1,0 +1,157 @@
+import { AdminApiClient } from '../../admin/index'
+import { matrix } from '../../test-support/testTags'
+
+vi.setConfig({ testTimeout: 15_000 })
+
+const saasMatrix = matrix({
+	include: {
+		versions: ['8.8', '8.7'],
+		deployments: ['saas'],
+		tenancy: ['single-tenant', 'multi-tenant'],
+		security: ['secured', 'unsecured'],
+	},
+})
+
+describe('AdminApiClient - new operations', () => {
+	let c: AdminApiClient
+	let clusterUuid: string
+
+	beforeAll(async () => {
+		c = new AdminApiClient()
+		const clusters = await c.getClusters()
+		expect(clusters.length).toBeGreaterThan(0)
+		clusterUuid = clusters[0].uuid
+	})
+
+	describe('Meta', () => {
+		test.runIf(saasMatrix)('getIpRanges', async () => {
+			const res = await c.getIpRanges()
+			expect(res).toBeTruthy()
+			expect(res['web-modeler']).toBeDefined()
+			expect(Array.isArray(res['web-modeler'])).toBe(true)
+		})
+	})
+
+	describe('Cluster management', () => {
+		test.runIf(saasMatrix)('getCluster returns cluster details', async () => {
+			const cluster = await c.getCluster(clusterUuid)
+			expect(cluster).toBeTruthy()
+			expect(cluster.uuid).toBe(clusterUuid)
+			expect(cluster.name).toBeTruthy()
+			expect(cluster.status).toBeTruthy()
+		})
+	})
+
+	describe('Secrets', () => {
+		const testSecretName = `__test_secret_${Date.now()}`
+		const testSecretValue = 'test-value-initial'
+		const updatedSecretValue = 'test-value-updated'
+
+		afterAll(async () => {
+			// Cleanup: delete test secret
+			await c.deleteSecret(clusterUuid, testSecretName).catch(() => {})
+		})
+
+		test.runIf(saasMatrix)('create and update a secret', async () => {
+			// Create
+			await c.createSecret({
+				clusterUuid,
+				secretName: testSecretName,
+				secretValue: testSecretValue,
+			})
+
+			// Verify it exists
+			const secrets = await c.getSecrets(clusterUuid)
+			expect(secrets[testSecretName]).toBe(testSecretValue)
+
+			// Update
+			await c.updateSecret(clusterUuid, testSecretName, updatedSecretValue)
+
+			// Verify update
+			const updatedSecrets = await c.getSecrets(clusterUuid)
+			expect(updatedSecrets[testSecretName]).toBe(updatedSecretValue)
+		})
+	})
+
+	describe('IP Allowlist', () => {
+		test.runIf(saasMatrix)(
+			'updateIpAllowlist can set and clear an allowlist',
+			async () => {
+				// Set a test allowlist entry
+				await c.updateIpAllowlist(clusterUuid, [
+					{ description: '__test_entry', ip: '203.0.113.0/24' },
+				])
+
+				// Clear the allowlist to restore original state
+				await c.updateIpAllowlist(clusterUuid, [])
+			}
+		)
+	})
+
+	describe('Backups', () => {
+		test.runIf(saasMatrix)('getBackups returns an array', async () => {
+			const backups = await c.getBackups(clusterUuid)
+			expect(Array.isArray(backups)).toBe(true)
+		})
+	})
+
+	describe('Secure Connectivity', () => {
+		test.runIf(saasMatrix)(
+			'getSecureConnectivityStatus returns status',
+			async () => {
+				const status = await c.getSecureConnectivityStatus(clusterUuid)
+				expect(status).toBeTruthy()
+				expect(status.status).toBeDefined()
+			}
+		)
+	})
+
+	describe('Monitoring', () => {
+		test.runIf(saasMatrix)(
+			'getMonitoringClients returns response',
+			async () => {
+				const res = await c.getMonitoringClients(clusterUuid)
+				expect(res).toBeTruthy()
+				expect(res.clients).toBeDefined()
+				expect(Array.isArray(res.clients)).toBe(true)
+			}
+		)
+	})
+
+	describe('Activity / Audit', () => {
+		test.runIf(saasMatrix)(
+			'getActivityEvents returns audit events',
+			async () => {
+				const events = await c.getActivityEvents()
+				expect(Array.isArray(events)).toBe(true)
+				if (events.length > 0) {
+					expect(events[0].service).toBeDefined()
+					expect(events[0].orgId).toBeDefined()
+					expect(events[0].timestamp).toBeDefined()
+					expect(events[0].auditType).toBeDefined()
+				}
+			}
+		)
+
+		test.runIf(saasMatrix)(
+			'getActivityEventsCsv returns a CSV string',
+			async () => {
+				const csv = await c.getActivityEventsCsv()
+				expect(typeof csv).toBe('string')
+			}
+		)
+	})
+
+	describe('Members', () => {
+		test.runIf(saasMatrix)(
+			'getUsers returns organization members',
+			async () => {
+				const members = await c.getUsers()
+				expect(Array.isArray(members)).toBe(true)
+				expect(members.length).toBeGreaterThan(0)
+				expect(members[0].email).toBeDefined()
+				expect(members[0].roles).toBeDefined()
+			}
+		)
+	})
+})

--- a/src/admin/lib/AdminApiClient.ts
+++ b/src/admin/lib/AdminApiClient.ts
@@ -2,16 +2,16 @@ import d from 'debug'
 import got from 'got'
 
 import {
-	CamundaEnvironmentConfigurator,
-	CamundaPlatform8Configuration,
-	DeepPartial,
-	GetCustomCertificateBuffer,
-	GotRetryConfig,
-	RequireConfiguration,
-	beforeCallHook,
-	constructOAuthProvider,
-	createUserAgentString,
-	gotBeforeErrorHook,
+    CamundaEnvironmentConfigurator,
+    CamundaPlatform8Configuration,
+    DeepPartial,
+    GetCustomCertificateBuffer,
+    GotRetryConfig,
+    RequireConfiguration,
+    beforeCallHook,
+    constructOAuthProvider,
+    createUserAgentString,
+    gotBeforeErrorHook,
 } from '../../lib'
 import { IHeadersProvider } from '../../oauth'
 
@@ -351,5 +351,343 @@ export class AdminApiClient {
 				headers,
 			})
 			.json()
+	}
+
+	/**
+	 *
+	 * Get the egress IP ranges for Camunda SaaS. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/GetMeta) for more details.
+	 * @throws {RESTError}
+	 */
+	async getIpRanges(): Promise<Dto.MetaDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest('meta/ip-ranges', {
+			headers,
+		}).json()
+	}
+
+	/**
+	 *
+	 * Update a cluster's name, description, or stage label. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/UpdateCluster) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param updateRequest - The fields to update
+	 * @throws {RESTError}
+	 */
+	async updateCluster(
+		clusterUuid: string,
+		updateRequest: Dto.UpdateClusterBody
+	): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.patch(`clusters/${clusterUuid}`, {
+			body: JSON.stringify(updateRequest),
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Upgrade a cluster to the latest available generation. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/UpgradeCluster) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async upgradeCluster(
+		clusterUuid: string
+	): Promise<Dto.GenerationUpgradeForClusterDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.put(`clusters/${clusterUuid}/upgrade`, {
+				headers,
+			})
+			.json()
+	}
+
+	/**
+	 *
+	 * Resume a suspended cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/Wake) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async wakeCluster(clusterUuid: string): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.put(`clusters/${clusterUuid}/wake`, {
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Update the IP allowlist for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/UpdateIpAllowlist) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param ipallowlist - Array of IP allowlist entries
+	 * @throws {RESTError}
+	 */
+	async updateIpAllowlist(
+		clusterUuid: string,
+		ipallowlist: Dto.IpAllowListEntry[]
+	): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.put(`clusters/${clusterUuid}/ipallowlist`, {
+			body: JSON.stringify({ ipallowlist }),
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Update a connector secret value. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/UpdateSecret) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param secretName - The name of the secret to update
+	 * @param secretValue - The new secret value
+	 * @throws {RESTError}
+	 */
+	async updateSecret(
+		clusterUuid: string,
+		secretName: string,
+		secretValue: string
+	): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.put(`clusters/${clusterUuid}/secrets/${secretName}`, {
+			body: JSON.stringify({ secretValue }),
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Activate Secure Connectivity for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/ActivateSecureConnectivity) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param request - The allowed principals and regions
+	 * @throws {RESTError}
+	 */
+	async activateSecureConnectivity(
+		clusterUuid: string,
+		request: Dto.ActivateSecureConnectivityBody
+	): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.post(`clusters/${clusterUuid}/secure-connectivity`, {
+			body: JSON.stringify(request),
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Deactivate Secure Connectivity for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/DeactivateSecureConnectivity) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async deactivateSecureConnectivity(clusterUuid: string): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.delete(`clusters/${clusterUuid}/secure-connectivity`, {
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Get the Secure Connectivity status for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/GetSecureConnectivityStatus) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async getSecureConnectivityStatus(
+		clusterUuid: string
+	): Promise<Dto.SecureConnectivityStatusResponse> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest(`clusters/${clusterUuid}/secure-connectivity`, {
+			headers,
+		}).json()
+	}
+
+	/**
+	 *
+	 * Activate External Monitoring (BYOM) for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/ActivateMonitoring) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async activateMonitoring(clusterUuid: string): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.post(`clusters/${clusterUuid}/monitoring`, {
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Deactivate External Monitoring (BYOM) for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/DeactivateMonitoring) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async deactivateMonitoring(clusterUuid: string): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.delete(`clusters/${clusterUuid}/monitoring`, {
+			headers,
+		})
+	}
+
+	/**
+	 *
+	 * Get all External Monitoring clients for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/GetMonitoringClients) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async getMonitoringClients(
+		clusterUuid: string
+	): Promise<Dto.MonitoringClientsResponse> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest(`clusters/${clusterUuid}/monitoring/clients`, {
+			headers,
+		}).json()
+	}
+
+	/**
+	 *
+	 * Create a new External Monitoring client for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/CreateMonitoringClient) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param username - The username for the monitoring client
+	 * @throws {RESTError}
+	 */
+	async createMonitoringClient(
+		clusterUuid: string,
+		username: string
+	): Promise<Dto.CreatedMonitoringClient> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.post(`clusters/${clusterUuid}/monitoring/clients`, {
+				body: JSON.stringify({ username }),
+				headers,
+			})
+			.json()
+	}
+
+	/**
+	 *
+	 * Rotate the password for an External Monitoring client. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/RotateMonitoringClientPassword) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param clientUuid - The monitoring client UUID
+	 * @throws {RESTError}
+	 */
+	async rotateMonitoringClientPassword(
+		clusterUuid: string,
+		clientUuid: string
+	): Promise<Dto.CreatedMonitoringClient> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.post(
+				`clusters/${clusterUuid}/monitoring/clients/${clientUuid}/rotate`,
+				{
+					headers,
+				}
+			)
+			.json()
+	}
+
+	/**
+	 *
+	 * Delete an External Monitoring client. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/DeleteMonitoringClient) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param clientUuid - The monitoring client UUID
+	 * @throws {RESTError}
+	 */
+	async deleteMonitoringClient(
+		clusterUuid: string,
+		clientUuid: string
+	): Promise<void> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		await rest.delete(
+			`clusters/${clusterUuid}/monitoring/clients/${clientUuid}`,
+			{
+				headers,
+			}
+		)
+	}
+
+	/**
+	 *
+	 * Get all backups for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/GetBackups) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async getBackups(clusterUuid: string): Promise<Dto.Backup[]> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest(`clusters/${clusterUuid}/backups`, {
+			headers,
+		}).json()
+	}
+
+	/**
+	 *
+	 * Create a new backup for a cluster. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/CreateBackup) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @throws {RESTError}
+	 */
+	async createBackup(clusterUuid: string): Promise<Dto.Backup> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.post(`clusters/${clusterUuid}/backups`, {
+				headers,
+			})
+			.json()
+	}
+
+	/**
+	 *
+	 * Delete a backup. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/DeleteBackup) for more details.
+	 * @param clusterUuid - The cluster UUID
+	 * @param backupId - The backup ID
+	 * @throws {RESTError}
+	 */
+	async deleteBackup(
+		clusterUuid: string,
+		backupId: string
+	): Promise<Dto.Backup> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.delete(`clusters/${clusterUuid}/backups/${backupId}`, {
+				headers,
+			})
+			.json()
+	}
+
+	/**
+	 *
+	 * Fetch all activity/audit events as JSON. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/GetJson) for more details.
+	 * @throws {RESTError}
+	 */
+	async getActivityEvents(): Promise<Dto.AuditEvent[]> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest('activity/json', {
+			headers,
+		}).json()
+	}
+
+	/**
+	 *
+	 * Fetch all activity/audit events as CSV. See [the API Documentation](https://console.cloud.camunda.io/customer-api/openapi/docs/#/default/GetCsv) for more details.
+	 * @throws {RESTError}
+	 */
+	async getActivityEventsCsv(): Promise<string> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest('activity/csv', {
+			headers,
+		}).text()
 	}
 }

--- a/src/admin/lib/AdminApiClient.ts
+++ b/src/admin/lib/AdminApiClient.ts
@@ -2,16 +2,16 @@ import d from 'debug'
 import got from 'got'
 
 import {
-    CamundaEnvironmentConfigurator,
-    CamundaPlatform8Configuration,
-    DeepPartial,
-    GetCustomCertificateBuffer,
-    GotRetryConfig,
-    RequireConfiguration,
-    beforeCallHook,
-    constructOAuthProvider,
-    createUserAgentString,
-    gotBeforeErrorHook,
+	CamundaEnvironmentConfigurator,
+	CamundaPlatform8Configuration,
+	DeepPartial,
+	GetCustomCertificateBuffer,
+	GotRetryConfig,
+	RequireConfiguration,
+	beforeCallHook,
+	constructOAuthProvider,
+	createUserAgentString,
+	gotBeforeErrorHook,
 } from '../../lib'
 import { IHeadersProvider } from '../../oauth'
 
@@ -585,12 +585,9 @@ export class AdminApiClient {
 		const headers = await this.getHeaders()
 		const rest = await this.rest
 		return rest
-			.post(
-				`clusters/${clusterUuid}/monitoring/clients/${clientUuid}/rotate`,
-				{
-					headers,
-				}
-			)
+			.post(`clusters/${clusterUuid}/monitoring/clients/${clientUuid}/rotate`, {
+				headers,
+			})
 			.json()
 	}
 

--- a/src/admin/lib/AdminDto.ts
+++ b/src/admin/lib/AdminDto.ts
@@ -124,3 +124,155 @@ export interface Member {
 	roles: OrganizationRole[]
 	invitePending: boolean
 }
+
+export interface MetaDto {
+	'web-modeler': string[]
+}
+
+export type CamundaClusterStage = 'dev' | 'test' | 'stage' | 'prod'
+
+export interface UpdateClusterBody {
+	name?: string
+	description?: string
+	stageLabel?: CamundaClusterStage
+	numberOfAllocatedHwPackages?: number
+}
+
+export interface GenerationUpgradeForClusterDto {
+	cluster: {
+		id: string
+		name: string
+	}
+	oldGeneration: {
+		id: string
+		name: string
+	}
+	newGeneration: {
+		id: string
+		name: string
+	}
+	orgId: string
+}
+
+export interface IpAllowListEntry {
+	description: string
+	ip: string
+}
+
+export interface ActivateSecureConnectivityBody {
+	allowedPrincipals: string[]
+	allowedRegions: string[]
+}
+
+export interface SecureConnectivityEndpointConnection {
+	state: string
+	serviceId: string
+	owner: string
+	endpointId: string
+	creationTimestamp: string
+}
+
+export interface SecureConnectivityCondition {
+	lastTransitionTime: string
+	observedGeneration: number
+	message: string
+	reason: string
+	status: string
+	type: string
+}
+
+export interface SecureConnectivityDto {
+	status: {
+		urls: Record<string, unknown>
+		observedGeneration: number
+		endpointConnections: SecureConnectivityEndpointConnection[]
+		endpointConnectionCount: number
+		endpoint: {
+			privateDnsName: string
+			type: string
+			serviceName: string
+			region: string
+		}
+		conditions: SecureConnectivityCondition[]
+	}
+	metadata: {
+		name: string
+		labels: {
+			orgId: string
+		}
+		namespace: string
+	}
+	spec: {
+		allowedPrincipals: string[]
+		allowedRegions: string[]
+		cluster: {
+			id: string
+		}
+	}
+}
+
+export interface SecureConnectivityStatusResponse {
+	status: SecureConnectivityDto | Record<string, never>
+}
+
+export interface MonitoringClient {
+	uuid: string
+	name: string
+	username: string
+	created: string
+	lastUsed: string
+	createdBy: string
+	createdByName: string
+}
+
+export interface CreatedMonitoringClient extends MonitoringClient {
+	password: string
+}
+
+export interface MonitoringMetricsEndpoint {
+	target: string
+	scheme: string
+	path: string
+}
+
+export interface MonitoringStatus {
+	metricsEndpoint: MonitoringMetricsEndpoint
+	conditions: unknown[]
+}
+
+export interface MonitoringClientsResponse {
+	clients: MonitoringClient[]
+	status: MonitoringStatus | Record<string, never>
+}
+
+export type BackupStatus = 'In progress' | 'Failed' | 'Complete' | '-'
+
+export interface Backup {
+	uuid: string
+	name: string
+	created: string
+	completed: string
+	status: BackupStatus
+	zeebeStatus: BackupStatus
+	tasklistStatus: BackupStatus
+	operateStatus: BackupStatus
+	optimizeStatus: BackupStatus
+}
+
+export type AuditType = 'c' | 'r' | 'u' | 'd'
+
+export interface AuditEvent {
+	service: string
+	orgId: string
+	timestamp: number
+	audit: string
+	auditType: AuditType
+	entity: string
+	entityId: string
+	userId: string
+	parentEntity?: string
+	parentEntityId?: string
+	entityAttribute?: string
+	entityAttributeValueFrom?: string
+	entityAttributeValueTo?: string
+}

--- a/src/zeebe/lib/cancelProcesses.ts
+++ b/src/zeebe/lib/cancelProcesses.ts
@@ -1,12 +1,13 @@
 import { Camunda8 } from '../../c8'
-import { OperateApiClient } from '../../operate'
 
-const operate = new OperateApiClient()
-const camunda = new Camunda8().getCamundaRestClient()
-const topology = camunda.getTopology()
+const c8 = new Camunda8()
+const camunda = c8.getCamundaRestClient()
+const operate = c8.getOperateApiClient()
 
 export async function cancelProcesses(processDefinitionKey: string) {
-	const gatewayVersion = (await topology).gatewayVersion
+	const topology = await camunda.getTopology()
+
+	const gatewayVersion = topology.gatewayVersion
 	const [major, minor] = gatewayVersion.split('.').map(Number)
 	const useCamundaRestClient = major > 8 || (major === 8 && minor >= 8)
 	const { searchProcessInstances, cancelProcessInstance } = useCamundaRestClient


### PR DESCRIPTION
Adds 20 missing Admin API operations bringing coverage from 44% (16/36) to 100% (36/36).

## New operations

**Meta**
- `getIpRanges()` — GET `/meta/ip-ranges`

**Cluster management**
- `updateCluster()` — PATCH `/clusters/{clusterUuid}`
- `upgradeCluster()` — PUT `/clusters/{clusterUuid}/upgrade`
- `wakeCluster()` — PUT `/clusters/{clusterUuid}/wake`

**IP Allowlist**
- `updateIpAllowlist()` — PUT `/clusters/{clusterUuid}/ipallowlist`

**Secrets**
- `updateSecret()` — PUT `/clusters/{clusterUuid}/secrets/{secretName}`

**Secure Connectivity**
- `activateSecureConnectivity()` — POST `/clusters/{clusterUuid}/secure-connectivity`
- `deactivateSecureConnectivity()` — DELETE `/clusters/{clusterUuid}/secure-connectivity`
- `getSecureConnectivityStatus()` — GET `/clusters/{clusterUuid}/secure-connectivity`

**External Monitoring (BYOM)**
- `activateMonitoring()` — POST `/clusters/{clusterUuid}/monitoring`
- `deactivateMonitoring()` — DELETE `/clusters/{clusterUuid}/monitoring`
- `getMonitoringClients()` — GET `/clusters/{clusterUuid}/monitoring/clients`
- `createMonitoringClient()` — POST `/clusters/{clusterUuid}/monitoring/clients`
- `rotateMonitoringClientPassword()` — POST `.../clients/{clientUuid}/rotate`
- `deleteMonitoringClient()` — DELETE `.../clients/{clientUuid}`

**Backups**
- `getBackups()` — GET `/clusters/{clusterUuid}/backups`
- `createBackup()` — POST `/clusters/{clusterUuid}/backups`
- `deleteBackup()` — DELETE `/clusters/{clusterUuid}/backups/{backupId}`

**Activity / Audit**
- `getActivityEvents()` — GET `/activity/json`
- `getActivityEventsCsv()` — GET `/activity/csv`

Closes #713