### PR TITLE
ci: enable fork PR checks against 8.8 and 8.9, gate SaaS to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,12 @@ name: CI
 on:
   push:
     branches-ignore:
-      - main
       - "stable/**"
   pull_request:
 
 jobs:
+  # Runs on every push (non-stable branches) and every pull request, including
+  # pull requests from forks. No secrets required.
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -28,174 +29,9 @@ jobs:
       - name: Run Unit Tests
         run: npm run test
 
-  local_integration:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    environment:
-      name: selfhosted
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: npm install
-
-      # Workaround for https://github.com/actions/runner-images/issues/2821
-      - name: Remove mono blocking 8084 port
-        run: sudo lsof -t -i:8084 | xargs -r sudo kill -9
-
-      - name: Set up Docker
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username joshua.wulf --password-stdin registry.camunda.cloud
-
-      - name: Set up Docker Compose
-        run: |
-          docker compose -f docker/docker-compose.yaml -f docker/docker-compose-modeler.yaml up -d
-        timeout-minutes: 10
-
-      - name: Run Integration Tests
-        run: |
-          npm run test:8.7:sm
-        env:
-          ZEEBE_GRPC_ADDRESS: grpc://localhost:26500
-          ZEEBE_CLIENT_ID: zeebe
-          ZEEBE_CLIENT_SECRET: zecret
-          CAMUNDA_OAUTH_URL: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-          CAMUNDA_TASKLIST_BASE_URL: http://localhost:8082
-          CAMUNDA_OPERATE_BASE_URL: http://localhost:8081
-          CAMUNDA_OPTIMIZE_BASE_URL: http://localhost:8083
-          CAMUNDA_MODELER_BASE_URL: http://localhost:8070/api
-
-      - name: Cleanup
-        if: always()
-        run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose-modeler.yaml down
-
-  local_multitenancy_integration:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    environment:
-      name: selfhosted
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: npm install
-
-      # Workaround for https://github.com/actions/runner-images/issues/2821
-      - name: Remove mono blocking 8084 port
-        run: sudo lsof -t -i:8084 | xargs -r sudo kill -9
-
-      - name: Set up Docker
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username joshua.wulf --password-stdin registry.camunda.cloud
-
-      - name: Set up Docker Compose
-        run: |
-          docker compose -f docker/docker-compose-multitenancy.yaml -f docker/docker-compose-modeler.yaml up -d
-        timeout-minutes: 10
-
-      - name: Run Integration Tests
-        run: |
-          npm run test:8.7:mt
-        env:
-          ZEEBE_GRPC_ADDRESS: grpc://localhost:26500
-          ZEEBE_CLIENT_ID: zeebe
-          ZEEBE_CLIENT_SECRET: zecret
-          CAMUNDA_OAUTH_URL: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-          CAMUNDA_TASKLIST_BASE_URL: http://localhost:8082
-          CAMUNDA_OPERATE_BASE_URL: http://localhost:8081
-          CAMUNDA_OPTIMIZE_BASE_URL: http://localhost:8083
-          CAMUNDA_MODELER_BASE_URL: http://localhost:8070/api
-          # Needed for Multi-Tenancy
-          CAMUNDA_TENANT_ID: <default>
-
-      - name: Cleanup
-        if: always()
-        run: docker compose -f docker/docker-compose-multitenancy.yaml -f docker/docker-compose-modeler.yaml down
-
-  saas_integration:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    environment: integration
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run Integration Tests
-        run: |
-          npm run test:8.7:saas
-        env:
-          ZEEBE_REST_ADDRESS: ${{ vars.ZEEBE_REST_ADDRESS }}
-          ZEEBE_GRPC_ADDRESS: ${{ vars.ZEEBE_GRPC_ADDRESS }}
-          ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}
-          ZEEBE_AUTHORIZATION_SERVER_URL: ${{ vars.ZEEBE_AUTHORIZATION_SERVER_URL }}
-          ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
-          ZEEBE_TOKEN_AUDIENCE: ${{ vars.ZEEBE_TOKEN_AUDIENCE }}
-          CAMUNDA_OAUTH_URL: ${{ vars.CAMUNDA_OAUTH_URL }}
-          CAMUNDA_TASKLIST_BASE_URL: ${{ vars.CAMUNDA_TASKLIST_BASE_URL }}
-          CAMUNDA_OPERATE_BASE_URL: ${{ vars.CAMUNDA_OPERATE_BASE_URL }}
-          CAMUNDA_OPTIMIZE_BASE_URL: ${{ vars.CAMUNDA_OPTIMIZE_BASE_URL }}
-          CAMUNDA_MODELER_BASE_URL: https://modeler.cloud.camunda.io/api
-          CAMUNDA_CONSOLE_CLIENT_ID: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_ID }}
-          CAMUNDA_CONSOLE_CLIENT_SECRET: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_SECRET }}
-          CAMUNDA_CONSOLE_BASE_URL: ${{ vars.CAMUNDA_CONSOLE_BASE_URL }}
-          CAMUNDA_CONSOLE_OAUTH_AUDIENCE: ${{ vars.CAMUNDA_CONSOLE_OAUTH_AUDIENCE}}
-
-  saas_integration_8_8:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    environment: integration-8.8
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run Integration Tests
-        run: |
-          npm run test:8.8:saas
-        env:
-          ZEEBE_REST_ADDRESS: ${{ vars.ZEEBE_REST_ADDRESS }}
-          ZEEBE_GRPC_ADDRESS: ${{ vars.ZEEBE_GRPC_ADDRESS }}
-          ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}
-          ZEEBE_AUTHORIZATION_SERVER_URL: ${{ vars.ZEEBE_AUTHORIZATION_SERVER_URL }}
-          ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
-          ZEEBE_TOKEN_AUDIENCE: ${{ vars.ZEEBE_TOKEN_AUDIENCE }}
-          CAMUNDA_OAUTH_URL: ${{ vars.CAMUNDA_OAUTH_URL }}
-          CAMUNDA_TASKLIST_BASE_URL: ${{ vars.CAMUNDA_TASKLIST_BASE_URL }}
-          CAMUNDA_OPERATE_BASE_URL: ${{ vars.CAMUNDA_OPERATE_BASE_URL }}
-          CAMUNDA_OPTIMIZE_BASE_URL: ${{ vars.CAMUNDA_OPTIMIZE_BASE_URL }}
-          CAMUNDA_MODELER_BASE_URL: https://modeler.cloud.camunda.io/api
-          CAMUNDA_CONSOLE_CLIENT_ID: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_ID }}
-          CAMUNDA_CONSOLE_CLIENT_SECRET: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_SECRET }}
-          CAMUNDA_CONSOLE_BASE_URL: ${{ vars.CAMUNDA_CONSOLE_BASE_URL }}
-          CAMUNDA_CONSOLE_OAUTH_AUDIENCE: ${{ vars.CAMUNDA_CONSOLE_OAUTH_AUDIENCE }}
-
+  # 8.8 self-managed integration tests. Uses only the public docker-compose
+  # stack — no secrets required. Runs on every push and every pull request
+  # (including fork PRs) so external contributors get PR feedback.
   local_integration_8_8:
     runs-on: ubuntu-latest
     steps:
@@ -243,6 +79,8 @@ jobs:
         if: always()
         run: docker compose -f docker/docker-compose-8.8.yaml down
 
+  # 8.8 test suite run against an 8.9 self-managed broker. Public stack — no
+  # secrets required. Runs on every push and every pull request.
   local_integration_8_8_against_8_9:
     runs-on: ubuntu-latest
     steps:
@@ -289,3 +127,79 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker compose -f docker/8.9/docker-compose.yaml down
+
+  # SaaS integration tests hit real SaaS endpoints and require environment
+  # secrets. To protect secret material and avoid running untrusted code
+  # against production-like infrastructure, these only run on pushes to
+  # `main` — i.e. after a PR has been reviewed and merged.
+  saas_integration:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: integration
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Integration Tests
+        run: |
+          npm run test:8.7:saas
+        env:
+          ZEEBE_REST_ADDRESS: ${{ vars.ZEEBE_REST_ADDRESS }}
+          ZEEBE_GRPC_ADDRESS: ${{ vars.ZEEBE_GRPC_ADDRESS }}
+          ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}
+          ZEEBE_AUTHORIZATION_SERVER_URL: ${{ vars.ZEEBE_AUTHORIZATION_SERVER_URL }}
+          ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
+          ZEEBE_TOKEN_AUDIENCE: ${{ vars.ZEEBE_TOKEN_AUDIENCE }}
+          CAMUNDA_OAUTH_URL: ${{ vars.CAMUNDA_OAUTH_URL }}
+          CAMUNDA_TASKLIST_BASE_URL: ${{ vars.CAMUNDA_TASKLIST_BASE_URL }}
+          CAMUNDA_OPERATE_BASE_URL: ${{ vars.CAMUNDA_OPERATE_BASE_URL }}
+          CAMUNDA_OPTIMIZE_BASE_URL: ${{ vars.CAMUNDA_OPTIMIZE_BASE_URL }}
+          CAMUNDA_MODELER_BASE_URL: https://modeler.cloud.camunda.io/api
+          CAMUNDA_CONSOLE_CLIENT_ID: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_ID }}
+          CAMUNDA_CONSOLE_CLIENT_SECRET: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_SECRET }}
+          CAMUNDA_CONSOLE_BASE_URL: ${{ vars.CAMUNDA_CONSOLE_BASE_URL }}
+          CAMUNDA_CONSOLE_OAUTH_AUDIENCE: ${{ vars.CAMUNDA_CONSOLE_OAUTH_AUDIENCE}}
+
+  # SaaS 8.8 integration. Same policy as saas_integration — main pushes only.
+  saas_integration_8_8:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: integration-8.8
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Integration Tests
+        run: |
+          npm run test:8.8:saas
+        env:
+          ZEEBE_REST_ADDRESS: ${{ vars.ZEEBE_REST_ADDRESS }}
+          ZEEBE_GRPC_ADDRESS: ${{ vars.ZEEBE_GRPC_ADDRESS }}
+          ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}
+          ZEEBE_AUTHORIZATION_SERVER_URL: ${{ vars.ZEEBE_AUTHORIZATION_SERVER_URL }}
+          ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
+          ZEEBE_TOKEN_AUDIENCE: ${{ vars.ZEEBE_TOKEN_AUDIENCE }}
+          CAMUNDA_OAUTH_URL: ${{ vars.CAMUNDA_OAUTH_URL }}
+          CAMUNDA_TASKLIST_BASE_URL: ${{ vars.CAMUNDA_TASKLIST_BASE_URL }}
+          CAMUNDA_OPERATE_BASE_URL: ${{ vars.CAMUNDA_OPERATE_BASE_URL }}
+          CAMUNDA_OPTIMIZE_BASE_URL: ${{ vars.CAMUNDA_OPTIMIZE_BASE_URL }}
+          CAMUNDA_MODELER_BASE_URL: https://modeler.cloud.camunda.io/api
+          CAMUNDA_CONSOLE_CLIENT_ID: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_ID }}
+          CAMUNDA_CONSOLE_CLIENT_SECRET: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_SECRET }}
+          CAMUNDA_CONSOLE_BASE_URL: ${{ vars.CAMUNDA_CONSOLE_BASE_URL }}


### PR DESCRIPTION
## Description of the change

Restructures `.github/workflows/ci.yml` so that external contributor PRs get useful CI feedback without exposing repository secrets.

### Before

- SaaS jobs (8.7 and 8.8) ran on every PR and required environment secrets, so fork PRs failed them.
- 8.7 self-managed jobs required `DOCKER_PASSWORD` to pull images from `registry.camunda.cloud`, so fork PRs failed those too.
- External contributor PRs (e.g. #722) had no meaningful green CI signal.

### After

- `unit-tests`, `local_integration_8_8`, and `local_integration_8_8_against_8_9` run on every push (non-stable branches) and every PR, including fork PRs. These jobs use only the public `docker-compose-8.8.yaml` / `docker/8.9/docker-compose.yaml` stacks and require no secrets — same setup style as `orchestration-cluster-api-js`.
- `saas_integration` (8.7) and `saas_integration_8_8` now only run on pushes to `main`, after a PR has been reviewed and merged. This keeps SaaS credentials away from untrusted code.
- The two 8.7 self-managed jobs that required `DOCKER_PASSWORD` have been removed. 8.7 coverage is retained via the SaaS 8.7 job on `main`.

## Type of change

- [x] Improvement

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] This PR targets `main`

Closes #725.

## Context

Motivated while reviewing #722 (fork PR).