### PR TITLE
ci: avoid duplicate pull_request + push CI runs on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,20 @@
 name: CI
 
 on:
-  # Only run on push for main — this triggers the SaaS jobs after merge.
-  # Feature branches are covered by the `pull_request` trigger below, which
-  # avoids duplicate (push) + (pull_request) runs on the same commit.
+  # Push triggers act as a stability gate: they run on `main` (post-merge,
+  # including SaaS jobs) and on `stable/**` branches (release stability).
+  # Feature branches are covered by the `pull_request` trigger, so listing
+  # them here would cause duplicate (push) + (pull_request) runs on the
+  # same commit.
   push:
     branches:
       - main
+      - "stable/**"
   pull_request:
 
 jobs:
-  # Runs on every push to main and every pull request, including
+  # Runs on every push to main or stable/**, and every pull request,
+  # including
   # pull requests from forks. No secrets required.
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
 name: CI
 
 on:
+  # Only run on push for main — this triggers the SaaS jobs after merge.
+  # Feature branches are covered by the `pull_request` trigger below, which
+  # avoids duplicate (push) + (pull_request) runs on the same commit.
   push:
-    branches-ignore:
-      - "stable/**"
+    branches:
+      - main
   pull_request:
 
 jobs:
-  # Runs on every push (non-stable branches) and every pull request, including
+  # Runs on every push to main and every pull request, including
   # pull requests from forks. No secrets required.
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Every commit on a feature branch with an open PR was firing CI twice on the same SHA:

- `CI / local_integration_8_8 (pull_request)`
- `CI / local_integration_8_8 (push)`

…and similarly for every other job. The `push` trigger was listening to every branch except `stable/**`, and `pull_request` fires on the same branch as soon as a PR is open. Both runs executed the same jobs.

## Fix

Restrict `on.push` to `main`. Feature branches are fully covered by `on.pull_request`.

```yaml
on:
  push:
    branches:
      - main
  pull_request:
```

## Behaviour preserved

- `pull_request` continues to run unit/8.8/8.9 on every PR, including forks — unchanged.
- SaaS jobs are still gated by `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so they run exactly once on merge to `main` — unchanged.
- Push to `stable/**` no longer runs CI — these were already excluded; the new config is stricter but in the same spirit. Stable branches are tested by scheduled compatibility matrix workflows.

## Type of change

- [x] Improvement