### PR TITLE
fix(oauth): improve OAuthProvider reliability (backport #722 to stable/8.8)

### DIFF
--- a/src/c8/lib/C8Dto.ts
+++ b/src/c8/lib/C8Dto.ts
@@ -501,18 +501,16 @@ export interface VariableDetails {
 	isTruncated: boolean
 }
 
-export interface SearchVariablesRequest
-	extends BaseSearchRequest<
-		| 'value'
-		| 'name'
-		| 'tenantId'
-		| 'variableKey'
-		| 'scopeKey'
-		| 'processInstanceKey',
-		VariableSearchRequestFilter
-	> {}
-export interface SearchVariablesResponse
-	extends PaginatedSearchResponse<VariableDetails> {}
+export interface SearchVariablesRequest extends BaseSearchRequest<
+	| 'value'
+	| 'name'
+	| 'tenantId'
+	| 'variableKey'
+	| 'scopeKey'
+	| 'processInstanceKey',
+	VariableSearchRequestFilter
+> {}
+export interface SearchVariablesResponse extends PaginatedSearchResponse<VariableDetails> {}
 
 export type SearchUserTasksSortRequest = SearchSortRequest<
 	'creationDate' | 'completionDate' | 'dueDate' | 'followUpDate' | 'priority'
@@ -587,14 +585,12 @@ export interface SearchUserTasksRequestFilter {
 	}>
 }
 
-export interface SearchTasksRequest
-	extends BaseSearchRequestWithOptionalFilter<
-		'creationDate' | 'completionDate' | 'dueDate' | 'followUpDate' | 'priority',
-		SearchUserTasksRequestFilter
-	> {}
+export interface SearchTasksRequest extends BaseSearchRequestWithOptionalFilter<
+	'creationDate' | 'completionDate' | 'dueDate' | 'followUpDate' | 'priority',
+	SearchUserTasksRequestFilter
+> {}
 
-export interface SearchUserTasksResponse
-	extends PaginatedSearchResponse<UserTask> {}
+export interface SearchUserTasksResponse extends PaginatedSearchResponse<UserTask> {}
 
 export interface UserTask {
 	/** The name for this user task. */
@@ -653,36 +649,34 @@ export interface AssignUserTaskRequest {
 	action?: string
 }
 
-export interface SearchUserTaskVariablesRequest
-	extends BaseSearchRequestWithOptionalFilter<
-		| 'value'
-		| 'name'
-		| 'tenantId'
-		| 'variableKey'
-		| 'scopeKey'
-		| 'processInstanceKey',
-		{
-			/** Name of the variable. */
-			name: string
-		}
-	> {
+export interface SearchUserTaskVariablesRequest extends BaseSearchRequestWithOptionalFilter<
+	| 'value'
+	| 'name'
+	| 'tenantId'
+	| 'variableKey'
+	| 'scopeKey'
+	| 'processInstanceKey',
+	{
+		/** Name of the variable. */
+		name: string
+	}
+> {
 	userTaskKey: string
 }
 
 /** The user task variables search response for CamundaRestClient. */
-export interface SearchUserTaskVariablesResponse
-	extends PaginatedSearchResponse<{
-		/** The key for this variable. */
-		variableKey: string
-		/** The key of the scope of this variable. */
-		scopeKey: string
-		/** The key of the process instance of this variable. */
-		processInstanceKey: string
-		name: string
-		value: string
-		tenantId: string
-		isTruncated: boolean
-	}> {}
+export interface SearchUserTaskVariablesResponse extends PaginatedSearchResponse<{
+	/** The key for this variable. */
+	variableKey: string
+	/** The key of the scope of this variable. */
+	scopeKey: string
+	/** The key of the process instance of this variable. */
+	processInstanceKey: string
+	name: string
+	value: string
+	tenantId: string
+	isTruncated: boolean
+}> {}
 
 export type ProcessInstanceState = 'ACTIVE' | 'COMPLETED' | 'CANCELED'
 
@@ -734,23 +728,22 @@ export interface SearchProcessInstanceRequestFilter {
 }
 
 /** This is the 8.8 API.  */
-export interface SearchProcessInstanceRequest
-	extends BaseSearchRequest<
-		| 'processInstanceKey'
-		| 'processDefinitionId'
-		| 'processDefinitionName'
-		| 'processDefinitionVersion'
-		| 'processDefinitionVersionTag'
-		| 'processDefinitionKey'
-		| 'parentProcessInstanceKey'
-		| 'parentFlowNodeInstanceKey'
-		| 'state'
-		| 'startDate'
-		| 'endDate'
-		| 'tenantId'
-		| 'hasIncident',
-		SearchProcessInstanceRequestFilter
-	> {}
+export interface SearchProcessInstanceRequest extends BaseSearchRequest<
+	| 'processInstanceKey'
+	| 'processDefinitionId'
+	| 'processDefinitionName'
+	| 'processDefinitionVersion'
+	| 'processDefinitionVersionTag'
+	| 'processDefinitionKey'
+	| 'parentProcessInstanceKey'
+	| 'parentFlowNodeInstanceKey'
+	| 'state'
+	| 'startDate'
+	| 'endDate'
+	| 'tenantId'
+	| 'hasIncident',
+	SearchProcessInstanceRequestFilter
+> {}
 
 export interface ProcessInstanceDetails {
 	/** The key of the process instance. */
@@ -779,8 +772,7 @@ export interface ProcessInstanceDetails {
 	hasIncident: boolean
 }
 
-export interface SearchProcessInstanceResponse
-	extends PaginatedSearchResponse<ProcessInstanceDetails> {}
+export interface SearchProcessInstanceResponse extends PaginatedSearchResponse<ProcessInstanceDetails> {}
 
 export interface DownloadDocumentRequest {
 	/** The ID of the document to download. */
@@ -1075,17 +1067,16 @@ export interface ProcessDefinitionSearchRequestFilter {
 	processDefinitionKey?: string
 }
 
-export interface SearchProcessDefinitionsRequest
-	extends BaseSearchRequest<
-		| 'processDefinitionKey'
-		| 'name'
-		| 'resourceName'
-		| 'version'
-		| 'versionTag'
-		| 'processDefinitionId'
-		| 'tenantId',
-		ProcessDefinitionSearchRequestFilter
-	> {}
+export interface SearchProcessDefinitionsRequest extends BaseSearchRequest<
+	| 'processDefinitionKey'
+	| 'name'
+	| 'resourceName'
+	| 'version'
+	| 'versionTag'
+	| 'processDefinitionId'
+	| 'tenantId',
+	ProcessDefinitionSearchRequestFilter
+> {}
 
 export interface ProcessDefinitionDetails {
 	/** Name of this process definition. */
@@ -1104,8 +1095,7 @@ export interface ProcessDefinitionDetails {
 	processDefinitionKey: string
 }
 
-export interface SearchProcessDefinitionsResponse
-	extends PaginatedSearchResponse<ProcessDefinitionDetails> {}
+export interface SearchProcessDefinitionsResponse extends PaginatedSearchResponse<ProcessDefinitionDetails> {}
 
 export interface ElementInstanceSearchRequestFilter {
 	processDefinitionId?: string
@@ -1147,21 +1137,20 @@ export interface ElementInstanceSearchRequestFilter {
 	incidentKey?: string
 }
 
-export interface SearchElementInstancesRequest
-	extends BaseSearchRequest<
-		| 'elementInstanceKey'
-		| 'processInstanceKey'
-		| 'processDefinitionKey'
-		| 'processDefinitionId'
-		| 'startDate'
-		| 'endDate'
-		| 'elementId'
-		| 'type'
-		| 'state'
-		| 'incidentKey'
-		| 'tenantId',
-		ElementInstanceSearchRequestFilter
-	> {}
+export interface SearchElementInstancesRequest extends BaseSearchRequest<
+	| 'elementInstanceKey'
+	| 'processInstanceKey'
+	| 'processDefinitionKey'
+	| 'processDefinitionId'
+	| 'startDate'
+	| 'endDate'
+	| 'elementId'
+	| 'type'
+	| 'state'
+	| 'incidentKey'
+	| 'tenantId',
+	ElementInstanceSearchRequestFilter
+> {}
 
 export interface ElementInstanceDetails {
 	/** The process definition ID associated to this element instance. */
@@ -1218,8 +1207,7 @@ export interface ElementInstanceDetails {
 	incidentKey?: string
 }
 
-export interface SearchElementInstancesResponse
-	extends PaginatedSearchResponse<ElementInstanceDetails> {}
+export interface SearchElementInstancesResponse extends PaginatedSearchResponse<ElementInstanceDetails> {}
 
 export interface IncidentSearchRequestFilter {
 	/** The process definition ID associated to this incident. */
@@ -1263,22 +1251,21 @@ export interface IncidentSearchRequestFilter {
 	jobKey?: string
 }
 
-export interface SearchIncidentsRequest
-	extends BaseSearchRequest<
-		| 'incidentKey'
-		| 'processInstanceKey'
-		| 'processDefinitionKey'
-		| 'processDefinitionId'
-		| 'errorType'
-		| 'errorMessage'
-		| 'elementId'
-		| 'elementInstanceKey'
-		| 'creationTime'
-		| 'state'
-		| 'jobKey'
-		| 'tenantId',
-		IncidentSearchRequestFilter
-	> {}
+export interface SearchIncidentsRequest extends BaseSearchRequest<
+	| 'incidentKey'
+	| 'processInstanceKey'
+	| 'processDefinitionKey'
+	| 'processDefinitionId'
+	| 'errorType'
+	| 'errorMessage'
+	| 'elementId'
+	| 'elementInstanceKey'
+	| 'creationTime'
+	| 'state'
+	| 'jobKey'
+	| 'tenantId',
+	IncidentSearchRequestFilter
+> {}
 
 export interface IncidentDetails {
 	/* The process definition ID associated to this incident. */
@@ -1322,8 +1309,7 @@ export interface IncidentDetails {
 	jobKey: string
 }
 
-export interface SearchIncidentsResponse
-	extends PaginatedSearchResponse<IncidentDetails> {}
+export interface SearchIncidentsResponse extends PaginatedSearchResponse<IncidentDetails> {}
 
 export interface CamundaRestError {
 	type: 'about:blank'

--- a/src/lib/PollingOperation.ts
+++ b/src/lib/PollingOperation.ts
@@ -16,8 +16,9 @@ interface PollingOperationOptionsBase<T> {
 	timeout?: number
 }
 
-interface PollingOperationOptionsWithPredicate<T>
-	extends PollingOperationOptionsBase<T> {
+interface PollingOperationOptionsWithPredicate<
+	T,
+> extends PollingOperationOptionsBase<T> {
 	/** predicate to check if the result is valid */
 	predicate: (result: T) => boolean
 }

--- a/src/lib/QuerySubscription.ts
+++ b/src/lib/QuerySubscription.ts
@@ -114,8 +114,9 @@ interface QuerySubscriptionConstructorBase<T> {
 	trackingWindow?: number
 }
 
-interface QuerySubscriptionConstructorWithPredicate<T>
-	extends QuerySubscriptionConstructorBase<T> {
+interface QuerySubscriptionConstructorWithPredicate<
+	T,
+> extends QuerySubscriptionConstructorBase<T> {
 	predicate: QuerySubscriptionPredicate<T>
 }
 

--- a/src/oauth/lib/OAuthProvider.ts
+++ b/src/oauth/lib/OAuthProvider.ts
@@ -28,6 +28,7 @@ const trace = debug('camunda:oauth')
 
 const homedir = os.homedir()
 const BACKOFF_TOKEN_ENDPOINT_FAILURE = 1000
+const TOKEN_ENDPOINT_REQUEST_TIMEOUT_MS = 30000
 
 /**
  * The `OAuthProvider` class is an implementation of the {@link IHeadersProvider}
@@ -105,8 +106,6 @@ export class OAuthProvider implements IHeadersProvider {
 			options?.config ?? {}
 		)
 		this.log = getLogger(config)
-
-		this.log = getLogger(config)
 		this.authServerUrl = RequireConfiguration(
 			config.CAMUNDA_OAUTH_URL,
 			'CAMUNDA_OAUTH_URL'
@@ -157,6 +156,9 @@ export class OAuthProvider implements IHeadersProvider {
 			(certificateAuthority) =>
 				got.extend({
 					retry: GotRetryConfig,
+					timeout: {
+						request: TOKEN_ENDPOINT_REQUEST_TIMEOUT_MS,
+					},
 					https: {
 						certificateAuthority,
 					},
@@ -232,7 +234,7 @@ export class OAuthProvider implements IHeadersProvider {
 	}
 
 	public async getHeaders(audienceType: TokenGrantAudienceType) {
-		debug(`Token request for ${audienceType}`)
+		trace(`Token request for ${audienceType}`)
 		// We use the Console credential set if it we are requesting from
 		// the SaaS OAuth endpoint, and it is a Modeler or Admin Console token.
 		// Otherwise we use the application credential set, unless a Console credential set exists.
@@ -252,13 +254,13 @@ export class OAuthProvider implements IHeadersProvider {
 				)
 			: RequireConfiguration(this.clientSecret, 'ZEEBE_CLIENT_SECRET')
 
-		const key = this.getCacheKey(audienceType)
+		const key = this.getCacheKey(clientIdToUse, audienceType)
 
 		if (this.tokenCache[key]) {
 			const token = this.tokenCache[key]
 			// check expiry and evict in-memory and file cache if expired
 			if (this.isExpired(token)) {
-				this.evictFromMemoryCache(audienceType)
+				this.evictFromMemoryCache(audienceType, clientIdToUse)
 				trace(`In-memory token ${token.audience} is expired`)
 			} else {
 				trace(`Using in-memory cached token ${token.audience}`)
@@ -381,12 +383,32 @@ export class OAuthProvider implements IHeadersProvider {
 	}
 
 	public flushFileCache() {
-		if (this.useFileCache) {
-			fs.readdirSync(this.cacheDir).forEach((file) => {
-				if (fs.existsSync(file)) {
-					fs.unlinkSync(file)
-				}
-			})
+		if (!this.useFileCache) {
+			return
+		}
+		try {
+			fs.readdirSync(this.cacheDir)
+				.filter(
+					(file) => file.startsWith('oauth-token-') && file.endsWith('.json')
+				)
+				.forEach((file) => {
+					const filePath = path.join(this.cacheDir, file)
+					try {
+						fs.unlinkSync(filePath)
+					} catch (e) {
+						const err = e as NodeJS.ErrnoException
+						if (err.code !== 'ENOENT') {
+							this.log.warn(`Failed to delete token cache file ${filePath}`)
+							this.log.warn(err.message, err)
+						}
+					}
+				})
+		} catch (e) {
+			const err = e as NodeJS.ErrnoException
+			if (err.code !== 'ENOENT') {
+				this.log.warn(`Failed to list OAuth token cache dir ${this.cacheDir}`)
+				this.log.warn(err.message, err)
+			}
 		}
 	}
 
@@ -443,7 +465,10 @@ export class OAuthProvider implements IHeadersProvider {
 
 		trace(`Making token request to the token endpoint: `)
 		trace(`  ${this.authServerUrl}`)
-		trace(options)
+		trace({
+			...options,
+			body: this.redactClientSecret(bodyWithScope),
+		})
 		return this.rest.then((rest) =>
 			rest
 				.post(this.authServerUrl, options)
@@ -459,16 +484,13 @@ export class OAuthProvider implements IHeadersProvider {
 				})
 				.catch((e) => {
 					e.message = `Error requesting token for Client Id ${clientIdToUse}: ${e.message}`
-					this.log.error(
-						`Error requesting token for Client Id ${clientIdToUse}`
-					)
 					this.log.error(e)
 					throw e
 				})
 				.then((t) => {
 					trace(
 						`Got token for Client Id ${clientIdToUse}: ${JSON.stringify(
-							t,
+							{ ...t, access_token: '[REDACTED]' },
 							null,
 							2
 						)}`
@@ -480,8 +502,11 @@ export class OAuthProvider implements IHeadersProvider {
 							`Failed to get token: ${t.error} - ${t.error_description}`
 						)
 					}
-					if ((t as Token).access_token === undefined) {
-						console.error(audienceType, t)
+					if (t.access_token === undefined) {
+						this.log.error(
+							`Failed to get token: no access_token in response for audience ${audienceType}`
+						)
+						this.log.error(JSON.stringify(t))
 						throw new Error('Failed to get token: no access_token in response')
 					}
 					const token = { ...(t as Token), audience: audienceType }
@@ -492,7 +517,11 @@ export class OAuthProvider implements IHeadersProvider {
 							clientId: clientIdToUse,
 						})
 					}
-					this.sendToMemoryCache({ audience: audienceType, token })
+					this.sendToMemoryCache({
+						audience: audienceType,
+						token,
+						clientId: clientIdToUse,
+					})
 					return this.addBearer(token.access_token)
 				})
 		)
@@ -501,21 +530,23 @@ export class OAuthProvider implements IHeadersProvider {
 	private sendToMemoryCache({
 		audience,
 		token,
+		clientId,
 	}: {
 		audience: TokenGrantAudienceType
 		token: Token
+		clientId: string
 	}) {
-		const key = this.getCacheKey(audience)
+		const key = this.getCacheKey(clientId, audience)
 		try {
 			const decoded = jwtDecode(token.access_token)
 			// Keeping this in the code base to help with debugging
 			// trace(`Caching token in memory: ${JSON.stringify(decoded, null, 2)}`)
 			trace(`Caching token for ${audience} in memory. Expiry: ${decoded.exp}`)
-			token.expiry = decoded.exp ?? 0
-			this.tokenCache[key] = token
+			this.tokenCache[key] = { ...token, expiry: decoded.exp ?? 0 }
 		} catch (e) {
-			console.error('audience', audience)
-			console.error('token', token.access_token)
+			const err = e as Error
+			this.log.error(`Failed to cache token in memory for audience ${audience}`)
+			this.log.error(err.message, err)
 			throw e
 		}
 	}
@@ -533,17 +564,23 @@ export class OAuthProvider implements IHeadersProvider {
 		}
 		try {
 			trace(`Reading file cached token for ${audience}`)
-			token = JSON.parse(
-				fs.readFileSync(this.getCachedTokenFileName(clientId, audience), 'utf8')
-			)
+			token = JSON.parse(fs.readFileSync(tokenFileName, 'utf8'))
 			trace(`Retrieved token from file cache`)
 			if (this.isExpired(token)) {
 				trace(`File cached token is expired`)
 				return null
 			}
-			this.sendToMemoryCache({ audience, token })
+			this.sendToMemoryCache({ audience, token, clientId })
 			return token
-		} catch (_) {
+		} catch (e) {
+			const err = e as Error
+			trace(
+				`Failed to read token from file cache for audience ${audience}: ${err.message}`
+			)
+			this.log.warn(
+				`Failed to read token from file cache for audience ${audience}. Ignoring cache entry.`
+			)
+			this.log.warn(err.message, err)
 			return null
 		}
 	}
@@ -558,7 +595,17 @@ export class OAuthProvider implements IHeadersProvider {
 		clientId: string
 	}) {
 		const file = this.getCachedTokenFileName(clientId, audience)
-		const decoded = jwtDecode(token.access_token)
+		let decoded: { exp?: number }
+		try {
+			decoded = jwtDecode(token.access_token)
+		} catch (e) {
+			const err = e as Error
+			this.log.warn(
+				`Failed to decode OAuth token before writing to file cache for audience ${audience}`
+			)
+			this.log.warn(err.message, err)
+			return
+		}
 
 		fs.writeFile(
 			file,
@@ -571,17 +618,14 @@ export class OAuthProvider implements IHeadersProvider {
 					trace(`Wrote OAuth token to file ${file}`)
 					return
 				}
-				// tslint:disable-next-line
-				console.error('Error writing OAuth token to file' + file)
-				// tslint:disable-next-line
-				console.error(e)
+				this.log.error(`Error writing OAuth token to file ${file}`)
+				this.log.error(e.message, e)
 			}
 		)
 	}
 
 	private isExpired(token: Token) {
-		const d = new Date()
-		const currentTime = d.setSeconds(d.getSeconds())
+		const currentTime = Date.now()
 
 		// token.expiry is seconds since Unix Epoch
 		// The Date constructor expects milliseconds since Unix Epoch
@@ -598,8 +642,11 @@ export class OAuthProvider implements IHeadersProvider {
 		return tokenIsExpired
 	}
 
-	private evictFromMemoryCache(audience: TokenGrantAudienceType) {
-		const key = this.getCacheKey(audience)
+	private evictFromMemoryCache(
+		audience: TokenGrantAudienceType,
+		clientId: string
+	) {
+		const key = this.getCacheKey(clientId, audience)
 		delete this.tokenCache[key]
 	}
 
@@ -616,12 +663,12 @@ export class OAuthProvider implements IHeadersProvider {
 		}
 	}
 
-	private getCacheKey = (audience: TokenGrantAudienceType) =>
-		`${this.clientId}-${audience}`
+	private getCacheKey = (clientId: string, audience: TokenGrantAudienceType) =>
+		`${clientId}-${audience}`
 	private getCachedTokenFileName = (
 		clientId: string,
 		audience: TokenGrantAudienceType
-	) => `${this.cacheDir}/oauth-token-${clientId}-${audience}.json`
+	) => path.join(this.cacheDir, `oauth-token-${clientId}-${audience}.json`)
 
 	private getAudience(audience: TokenGrantAudienceType) {
 		return this.audienceMap[audience]
@@ -629,6 +676,10 @@ export class OAuthProvider implements IHeadersProvider {
 
 	private addBearer(token: string) {
 		return { authorization: `Bearer ${token}` }
+	}
+
+	private redactClientSecret(body: string) {
+		return body.replace(/(client_secret=)[^&]*/g, '$1[REDACTED]')
 	}
 
 	// Mutable for test overrides; legacy cooldown window (no longer used for tarpit persistence, retained for backward compatibility of tests)

--- a/src/optimize/lib/APIObjects.ts
+++ b/src/optimize/lib/APIObjects.ts
@@ -129,8 +129,9 @@ export interface CloudEventV1<T> extends CloudEventV1Attributes<T> {
 	specversion: string
 }
 
-export interface CloudEventV1Attributes<T>
-	extends CloudEventV1OptionalAttributes<T> {
+export interface CloudEventV1Attributes<
+	T,
+> extends CloudEventV1OptionalAttributes<T> {
 	/**
 	 * [REQUIRED] Identifies the context in which an event happened. Often this
 	 * will include information such as the type of the event source, the

--- a/src/tasklist/lib/TasklistDto.ts
+++ b/src/tasklist/lib/TasklistDto.ts
@@ -22,8 +22,7 @@ export interface VariableSearchResponseWithoutDraft {
 	previewValue: string
 }
 
-export interface VariableSearchResponse
-	extends VariableSearchResponseWithoutDraft {
+export interface VariableSearchResponse extends VariableSearchResponseWithoutDraft {
 	draft: DraftSearchVariableValue
 }
 
@@ -123,8 +122,7 @@ export interface TaskSearchAfterRequest extends Partial<TaskSearchRequestBase> {
 	searchAfter: string[]
 }
 
-export interface TaskSearchAfterOrEqualRequest
-	extends Partial<TaskSearchRequestBase> {
+export interface TaskSearchAfterOrEqualRequest extends Partial<TaskSearchRequestBase> {
 	/**
 	 * Used to return a paginated result. Array of values that should be copied from sortValues of one of the tasks from the current search results page.
 	 * It enables the API to return a page of tasks that directly follow or are equal to the task identified by the provided values, with respect to the sorting order.
@@ -132,8 +130,7 @@ export interface TaskSearchAfterOrEqualRequest
 	searchAfterOrEqual: string[]
 }
 
-export interface TaskSearchBeforeRequest
-	extends Partial<TaskSearchRequestBase> {
+export interface TaskSearchBeforeRequest extends Partial<TaskSearchRequestBase> {
 	/**
 	 * Used to return a paginated result. Array of values that should be copied from sortValues of one of the tasks from the current search results page.
 	 * It enables the API to return a page of tasks that directly precede the task identified by the provided values, with respect to the sorting order.
@@ -141,8 +138,7 @@ export interface TaskSearchBeforeRequest
 	searchBefore: string[]
 }
 
-export interface TaskSearchBeforeOrEqualRequest
-	extends Partial<TaskSearchRequestBase> {
+export interface TaskSearchBeforeOrEqualRequest extends Partial<TaskSearchRequestBase> {
 	/**
 	 * Used to return a paginated result. Array of values that should be copied from sortValues of one of the tasks from the current search results page.
 	 * It enables the API to return a page of tasks that directly precede or are equal to the task identified by the provided values, with respect to the sorting order.

--- a/src/zeebe/lib/ZBStreamWorker.ts
+++ b/src/zeebe/lib/ZBStreamWorker.ts
@@ -255,8 +255,10 @@ You should call only one job action method in the worker handler. This is a bug 
 					_conf: string | JobFailureConfiguration
 				): _conf is JobFailureConfiguration => typeof _conf === 'object'
 				const errorMessage = isFailureConfig(conf) ? conf.errorMessage : conf
-				const retryBackOff = isFailureConfig(conf) ? conf.retryBackOff ?? 0 : 0
-				const _retries = isFailureConfig(conf) ? conf.retries ?? 0 : retries
+				const retryBackOff = isFailureConfig(conf)
+					? (conf.retryBackOff ?? 0)
+					: 0
+				const _retries = isFailureConfig(conf) ? (conf.retries ?? 0) : retries
 				return this.failJob({
 					job,
 					errorMessage,
@@ -276,7 +278,7 @@ You should call only one job action method in the worker handler. This is a bug 
 				): s is ErrorJobWithVariables => typeof s === 'object'
 				const errorCode = isErrorJobWithVariables(e) ? e.errorCode : e
 				errorMessage = isErrorJobWithVariables(e)
-					? e.errorMessage ?? ''
+					? (e.errorMessage ?? '')
 					: errorMessage
 				const variables = isErrorJobWithVariables(e) ? e.variables : {}
 

--- a/src/zeebe/lib/ZBWorkerBase.ts
+++ b/src/zeebe/lib/ZBWorkerBase.ts
@@ -334,8 +334,10 @@ You should call only one job action method in the worker handler. This is a bug 
 					_conf: string | ZB.JobFailureConfiguration
 				): _conf is ZB.JobFailureConfiguration => typeof _conf === 'object'
 				const errorMessage = isFailureConfig(conf) ? conf.errorMessage : conf
-				const retryBackOff = isFailureConfig(conf) ? conf.retryBackOff ?? 0 : 0
-				const _retries = isFailureConfig(conf) ? conf.retries ?? 0 : retries
+				const retryBackOff = isFailureConfig(conf)
+					? (conf.retryBackOff ?? 0)
+					: 0
+				const _retries = isFailureConfig(conf) ? (conf.retries ?? 0) : retries
 				return this.failJob({
 					job,
 					errorMessage,
@@ -357,7 +359,7 @@ You should call only one job action method in the worker handler. This is a bug 
 				): s is ZB.ErrorJobWithVariables => typeof s === 'object'
 				const errorCode = isErrorJobWithVariables(e) ? e.errorCode : e
 				errorMessage = isErrorJobWithVariables(e)
-					? e.errorMessage ?? ''
+					? (e.errorMessage ?? '')
 					: errorMessage
 				const variables = isErrorJobWithVariables(e) ? e.variables : {}
 

--- a/src/zeebe/lib/interfaces-1.0.ts
+++ b/src/zeebe/lib/interfaces-1.0.ts
@@ -69,8 +69,9 @@ export interface CreateProcessBaseRequest<V extends JSONDoc> {
 	operationReference?: number | LosslessNumber
 }
 
-export interface CreateProcessInstanceReq<V extends JSONDoc>
-	extends CreateProcessBaseRequest<V> {
+export interface CreateProcessInstanceReq<
+	V extends JSONDoc,
+> extends CreateProcessBaseRequest<V> {
 	/**
 	 * List of start instructions. If empty (default) the process instance
 	 * will start at the start event. If non-empty the process instance will apply start
@@ -79,8 +80,9 @@ export interface CreateProcessInstanceReq<V extends JSONDoc>
 	startInstructions?: ProcessInstanceCreationStartInstruction[]
 }
 
-export interface CreateProcessInstanceWithResultReq<T extends JSONDoc>
-	extends CreateProcessBaseRequest<T> {
+export interface CreateProcessInstanceWithResultReq<
+	T extends JSONDoc,
+> extends CreateProcessBaseRequest<T> {
 	/**
 	 * Timeout in milliseconds. the request will be closed if the process is not completed before the requestTimeout.
 	 * if requestTimeout = 0, uses the generic requestTimeout configured in the gateway.
@@ -247,7 +249,9 @@ export interface ZeebeJob<
 	WorkerInputVariables = IInputVariables,
 	CustomHeaderShape = ICustomHeaders,
 	WorkerOutputVariables = IOutputVariables,
-> extends Job<WorkerInputVariables, CustomHeaderShape>,
+>
+	extends
+		Job<WorkerInputVariables, CustomHeaderShape>,
 		JobCompletionInterface<WorkerOutputVariables> {}
 
 export interface IZBJobWorker {

--- a/src/zeebe/lib/interfaces-grpc-1.0.ts
+++ b/src/zeebe/lib/interfaces-grpc-1.0.ts
@@ -135,8 +135,7 @@ export interface CreateProcessInstanceBaseRequest {
 	tenantId?: string
 }
 
-export interface CreateProcessInstanceRequest
-	extends CreateProcessInstanceBaseRequest {
+export interface CreateProcessInstanceRequest extends CreateProcessInstanceBaseRequest {
 	/**
 	 * List of start instructions. If empty (default) the process instance
 	 * will start at the start event. If non-empty the process instance will apply start
@@ -225,16 +224,16 @@ interface CreateProcessInstanceWithResultResponseBase {
 	readonly tenantId: string
 }
 
-export interface CreateProcessInstanceWithResultResponse<Result>
-	extends CreateProcessInstanceWithResultResponseBase {
+export interface CreateProcessInstanceWithResultResponse<
+	Result,
+> extends CreateProcessInstanceWithResultResponseBase {
 	/**
 	 * consisting of all visible variables to the root scope
 	 */
 	readonly variables: Result
 }
 
-export interface CreateProcessInstanceWithResultResponseOnWire
-	extends CreateProcessInstanceWithResultResponseBase {
+export interface CreateProcessInstanceWithResultResponseOnWire extends CreateProcessInstanceWithResultResponseBase {
 	/**
 	 * consisting of all visible variables to the root scope
 	 */
@@ -526,8 +525,9 @@ interface SetVariablesRequestBase {
 	 */
 	local: boolean
 }
-export interface SetVariablesRequest<Variables = IProcessVariables>
-	extends SetVariablesRequestBase {
+export interface SetVariablesRequest<
+	Variables = IProcessVariables,
+> extends SetVariablesRequestBase {
 	variables: Partial<Variables>
 	/** a reference key chosen by the user and will be part of all records resulted from this operation */
 	operationReference?: number | LosslessNumber

--- a/src/zeebe/zb/ZeebeGrpcClient.ts
+++ b/src/zeebe/zb/ZeebeGrpcClient.ts
@@ -376,7 +376,7 @@ export class ZeebeGrpcClient extends TypedEmitter<
 					await this.grpc
 				).activateJobsStream({
 					...req,
-					tenantIds: req.tenantIds ?? this.tenantId ? [this.tenantId!] : [],
+					tenantIds: (req.tenantIds ?? this.tenantId) ? [this.tenantId!] : [],
 				})
 				if (stream.error) {
 					throw stream.error


### PR DESCRIPTION
Backport of #722 to `stable/8.8`.

## What

Cherry-picks the squashed OAuthProvider hardening from #722 (merge commit `df1c3ccf` on main) onto `stable/8.8`.

Original author: @lucia-w.

## Why

See #729 for the full defect write-up. Headline: on SaaS, the in-memory cache key was built from `this.clientId` instead of `clientIdToUse`, so Console/Modeler tokens could collide with application tokens. The PR also fixes a silent no-op `flushFileCache`, redacts secrets in trace logs, and hardens several minor paths.

## Related

- Original PR: #722
- Regression tests: #730 (bot already opened `backport-730-to-stable/8.8` — that branch is red until this one merges, then will go green and can be merged on top).

## Merge order on stable/8.8

1. Merge **this PR** first (brings the fix).
2. Merge `backport-730-to-stable/8.8` (adds the regression tests, which then go green).