### PR TITLE
ci: use npm ci for reproducible installs across all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build and Smoke Test
         run: npm run test:smoketest
@@ -51,7 +51,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       # Workaround for https://github.com/actions/runner-images/issues/2821
       - name: Remove mono blocking 8084 port
@@ -100,7 +100,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       # Workaround for https://github.com/actions/runner-images/issues/2821
       - name: Remove mono blocking 8084 port
@@ -153,7 +153,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run Integration Tests
         run: |
@@ -190,7 +190,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run Integration Tests
         run: |


### PR DESCRIPTION
## Problem

Every CI job runs `npm install`, which honours the caret ranges in `package.json` against the live registry and ignores `package-lock.json`. CI installs therefore drift from what's locked, and from what contributors install locally.

This is suspected to be a contributing factor to the recent SaaS 8.7 hard-fail in `src/__tests__/zeebe/integration/Worker-Failure-Retries.spec.ts`:

- Passes locally with the version of `@grpc/grpc-js` recorded in `package-lock.json`.
- Fails in CI with `Error: 7 PERMISSION_DENIED: Received HTTP status code 403` — i.e. the HTTP/2 layer in grpc-js is reporting a `:status 403` from the SaaS edge, not a Zeebe gateway gRPC `PERMISSION_DENIED`. Different patch versions of grpc-js have changed how short-lived HTTP/2 sessions are reused; this test creates 3 separate `ZeebeGrpcClient` instances back-to-back, which exposes that path.

## Fix

Replace `run: npm install` with `run: npm ci` in all five jobs:

- `unit-tests`
- `local_integration_8_8`
- `local_integration_8_8_against_8_9`
- `saas_integration` (8.7)
- `saas_integration_8_8`

`npm ci` installs strictly from `package-lock.json`, fails if the lockfile is out of sync, and is the standard CI install recipe.

## Verification plan

1. Merge this PR.
2. Watch the next `saas_integration` run on `main`.
   - If `Worker-Failure-Retries` passes → confirmed dependency drift, no further action.
   - If it still fails → drift is ruled out, narrow to runner-network / Node 22 vs local / SaaS 8.7 cluster behaviour.

## Type of change

- [x] Improvement (CI hygiene)

## Notes

This does not change any production code or test code. Lockfile already passes `npm ci` cleanly (verified locally — the install would have failed otherwise).