### PR TITLE
test(uploadDocument): skip flaky 8.7-sm tests pending #562

### DIFF
--- a/src/__tests__/8.7-sm-only/uploadDocument.spec.ts
+++ b/src/__tests__/8.7-sm-only/uploadDocument.spec.ts
@@ -10,51 +10,55 @@ vi.setConfig({ testTimeout: 30_000 })
 
 // Disabled because the test is flaky and the issue is not resolved yet.
 // See https://github.com/camunda/camunda-8-js-sdk/issues/562
-test.runIf(
-	matrix({
-		include: {
-			versions: ['8.8', '8.7'],
-			deployments: ['self-managed', 'saas'],
-			tenancy: ['single-tenant', 'multi-tenant'],
-			security: ['secured', 'unsecured'],
-		},
+test
+	.runIf(
+		matrix({
+			include: {
+				versions: ['8.8', '8.7'],
+				deployments: ['self-managed', 'saas'],
+				tenancy: ['single-tenant', 'multi-tenant'],
+				security: ['secured', 'unsecured'],
+			},
+		})
+	)
+	.skip('It can upload a document', async () => {
+		const response = await c8.uploadDocument({
+			file: fs.createReadStream('README.md'),
+			metadata: {
+				processDefinitionId: 'process-definition-id',
+			},
+		})
+		expect(response.metadata.processDefinitionId).toBe('process-definition-id')
+		expect(response.metadata.contentType).toBe('text/markdown')
 	})
-)('It can upload a document', async () => {
-	const response = await c8.uploadDocument({
-		file: fs.createReadStream('README.md'),
-		metadata: {
-			processDefinitionId: 'process-definition-id',
-		},
-	})
-	expect(response.metadata.processDefinitionId).toBe('process-definition-id')
-	expect(response.metadata.contentType).toBe('text/markdown')
-})
 
 // Disabled because the test is flaky and the issue is not resolved yet.
 // See https://github.com/camunda/camunda-8-js-sdk/issues/562
-test.runIf(
-	matrix({
-		include: {
-			versions: ['8.8', '8.7'],
-			deployments: ['self-managed', 'saas'],
-			tenancy: ['single-tenant', 'multi-tenant'],
-			security: ['secured', 'unsecured'],
-		},
-	})
-)('It can download a document', async () => {
-	const response = await c8.uploadDocument({
-		file: fs.createReadStream('README.md'),
-		metadata: {
-			processDefinitionId: 'process-definition-id',
-		},
-	})
-	expect(response.metadata.processDefinitionId).toBe('process-definition-id')
-	expect(response.metadata.contentType).toBe('text/markdown')
+test
+	.runIf(
+		matrix({
+			include: {
+				versions: ['8.8', '8.7'],
+				deployments: ['self-managed', 'saas'],
+				tenancy: ['single-tenant', 'multi-tenant'],
+				security: ['secured', 'unsecured'],
+			},
+		})
+	)
+	.skip('It can download a document', async () => {
+		const response = await c8.uploadDocument({
+			file: fs.createReadStream('README.md'),
+			metadata: {
+				processDefinitionId: 'process-definition-id',
+			},
+		})
+		expect(response.metadata.processDefinitionId).toBe('process-definition-id')
+		expect(response.metadata.contentType).toBe('text/markdown')
 
-	const downloadResponse = await c8.downloadDocument({
-		documentId: response.documentId,
-		contentHash: response.contentHash,
+		const downloadResponse = await c8.downloadDocument({
+			documentId: response.documentId,
+			contentHash: response.contentHash,
+		})
+		expect(downloadResponse).toBeTruthy()
+		expect(downloadResponse).toBeInstanceOf(Buffer)
 	})
-	expect(downloadResponse).toBeTruthy()
-	expect(downloadResponse).toBeInstanceOf(Buffer)
-})


### PR DESCRIPTION
## Problem

The two tests in `src/__tests__/8.7-sm-only/uploadDocument.spec.ts` already carry the comment:

```ts
// Disabled because the test is flaky and the issue is not resolved yet.
// See https://github.com/camunda/camunda-8-js-sdk/issues/562
```

…but the comment was the only mitigation. The tests still ran and intermittently failed whenever the matrix matched.

## Fix

Chain `.skip` onto `test.runIf(matrix(...))` so vitest reports them as skipped without executing:

```ts
test
  .runIf(matrix({ ... }))
  .skip('It can upload a document', async () => { ... })
```

Vitest's chained test object already exposes `.skip`, `.only`, and `.todo`, so no helper is needed. The matrix predicate is preserved — removing `.skip` once #562 lands re-enables the tests on the same environments.

## Type of change

- [x] Test hygiene