### PR TITLE
ci: drop CI workflow on push to stable/** (Release workflow covers it)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,10 @@
 name: CI
 
 on:
-  # Push trigger acts as a stability gate for `stable/**` branches only.
-  # Merges to `main` are handled by the Release workflow (which runs the
-  # full release pipeline including its own validation), so we don't
-  # double-up by also running CI here. Feature branches are covered by
-  # the `pull_request` trigger.
-  push:
-    branches:
-      - "stable/**"
+  # Feature branches and PRs (including forks) are covered by `pull_request`.
+  # Merges to `main` and `stable/**` are handled by the Release workflow,
+  # which runs the same non-gated jobs as part of its pipeline. Listing
+  # those branches here would just duplicate runs on the same SHA.
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Problem

Merging a PR to a `stable/**` branch fires both **CI** and **Release** on the same SHA. Release already runs the same non-gated jobs (`unit-tests`, `local_integration_8_8`, `local_integration_8_8_against_8_9`) on push to `stable/**`, so the parallel CI run is pure duplication.

## Fix

Restrict `ci.yml`'s push trigger to `main` only.

```yaml
on:
  push:
    branches:
      - main
  pull_request:
```

PR-targeting-stable coverage is unchanged: `pull_request` still fires on every PR (including forks), running exactly the 3 non-gated jobs.

## Note (out of scope)

This does **not** address the environment-approval prompts that `release.yml` requests on `stable/**` push (`selfhosted`, `integration`, `integration-8.8`, `publish`). That's a separate decision — likely either gating those jobs by ref or requiring `workflow_dispatch` for stable releases.

## Type of change

- [x] Improvement (CI hygiene)