### PR TITLE
[Backport stable/8.8] chore(deps): bump protobufjs from 7.5.4 to 7.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13491,9 +13491,9 @@
 			"license": "ISC"
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {


### PR DESCRIPTION
# Description
Backport of #727 to `stable/8.8`.

relates to 