### PR TITLE
ci: run non-blocking CI on push to feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
 name: CI
 
 on:
-  # Feature branches and PRs (including forks) are covered by `pull_request`.
+  # Push to a feature branch (anything except main and stable/**) runs the
+  # non-blocking CI suite for fast feedback before a PR is opened.
+  # `pull_request` then re-runs the same suite once a PR exists, so the
+  # author also sees the result against the PR's merge commit.
   # Merges to `main` and `stable/**` are handled by the Release workflow,
-  # which runs the same non-gated jobs as part of its pipeline. Listing
-  # those branches here would just duplicate runs on the same SHA.
+  # which runs the same non-gated jobs plus the gated integration / SaaS
+  # jobs as part of its pipeline. Listing those branches here would just
+  # duplicate runs on the same SHA.
+  push:
+    branches-ignore:
+      - main
+      - 'stable/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Problem

After PR #740 removed the `push:` trigger entirely, pushing to a feature branch with no open PR runs **nothing**. Authors get no CI signal until they explicitly open a PR.

This regressed against the desired behavior:

> On a push to a (feature) branch, the non-blocking CI tasks run.

## Fix

Re-add a `push:` trigger that excludes `main` and `stable/**` (those branches are owned by `release.yml`).

```yaml
on:
  push:
    branches-ignore:
      - main
      - 'stable/**'
  pull_request:
```

## Resulting matrix

| Trigger                                | Workflow                       |
| -------------------------------------- | ------------------------------ |
| Push to feature branch (no PR)         | `ci.yml` (3 non-blocking jobs) |
| PR to `main` or `stable/*`         | `ci.yml` (3 non-blocking jobs) |
| Push to feature branch with open PR    | `ci.yml` push run **and** `ci.yml` pull_request run |
| Merge to `main`                      | `release.yml` (3 non-blocking + 4 gated + publish) |
| Merge to `stable/*`                  | `release.yml` (3 non-blocking + 4 gated + publish) |

## Trade-off

In-repo PRs will see two CI runs per commit (push + pull_request). All 3 jobs in `ci.yml` are unsecreted and relatively cheap (`unit-tests`, `local_integration_8_8`, `local_integration_8_8_against_8_9`), so this is acceptable.

If we later want to eliminate that overlap, we can adopt the same disjoint split as PR #747 on `stable/8.8` — `pull_request: { types: [opened, reopened, ready_for_review] }` so the PR run only fires on PR creation.

## Type of change

- [x] Improvement (CI hygiene)