### PR TITLE
ci(stable/8.8): keep 8.7 SM jobs in ci.yml as PR-only non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
         run: npm run test
 
   local_integration:
-    if: github.actor != 'dependabot[bot]'
+    # 8.7 self-managed stack: heavy (full Camunda + Modeler). Run on PR only,
+    # not on every push to a feature branch. Uses DOCKER_PASSWORD from the
+    # `selfhosted` environment (no required reviewers — gate is implicit:
+    # fork PRs cannot read environment secrets and will skip the docker login).
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment:
       name: selfhosted
@@ -76,7 +80,8 @@ jobs:
         run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose-modeler.yaml down
 
   local_multitenancy_integration:
-    if: github.actor != 'dependabot[bot]'
+    # 8.7 self-managed multi-tenancy stack. Same trigger shape as local_integration.
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment:
       name: selfhosted
@@ -123,78 +128,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker compose -f docker/docker-compose-multitenancy.yaml -f docker/docker-compose-modeler.yaml down
-
-  saas_integration:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    environment: integration
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run Integration Tests
-        run: |
-          npm run test:8.7:saas
-        env:
-          ZEEBE_REST_ADDRESS: ${{ vars.ZEEBE_REST_ADDRESS }}
-          ZEEBE_GRPC_ADDRESS: ${{ vars.ZEEBE_GRPC_ADDRESS }}
-          ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}
-          ZEEBE_AUTHORIZATION_SERVER_URL: ${{ vars.ZEEBE_AUTHORIZATION_SERVER_URL }}
-          ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
-          ZEEBE_TOKEN_AUDIENCE: ${{ vars.ZEEBE_TOKEN_AUDIENCE }}
-          CAMUNDA_OAUTH_URL: ${{ vars.CAMUNDA_OAUTH_URL }}
-          CAMUNDA_TASKLIST_BASE_URL: ${{ vars.CAMUNDA_TASKLIST_BASE_URL }}
-          CAMUNDA_OPERATE_BASE_URL: ${{ vars.CAMUNDA_OPERATE_BASE_URL }}
-          CAMUNDA_OPTIMIZE_BASE_URL: ${{ vars.CAMUNDA_OPTIMIZE_BASE_URL }}
-          CAMUNDA_MODELER_BASE_URL: https://modeler.cloud.camunda.io/api
-          CAMUNDA_CONSOLE_CLIENT_ID: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_ID }}
-          CAMUNDA_CONSOLE_CLIENT_SECRET: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_SECRET }}
-          CAMUNDA_CONSOLE_BASE_URL: ${{ vars.CAMUNDA_CONSOLE_BASE_URL }}
-          CAMUNDA_CONSOLE_OAUTH_AUDIENCE: ${{ vars.CAMUNDA_CONSOLE_OAUTH_AUDIENCE}}
-
-  saas_integration_8_8:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    environment: integration-8.8
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run Integration Tests
-        run: |
-          npm run test:8.8:saas
-        env:
-          ZEEBE_REST_ADDRESS: ${{ vars.ZEEBE_REST_ADDRESS }}
-          ZEEBE_GRPC_ADDRESS: ${{ vars.ZEEBE_GRPC_ADDRESS }}
-          ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}
-          ZEEBE_AUTHORIZATION_SERVER_URL: ${{ vars.ZEEBE_AUTHORIZATION_SERVER_URL }}
-          ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
-          ZEEBE_TOKEN_AUDIENCE: ${{ vars.ZEEBE_TOKEN_AUDIENCE }}
-          CAMUNDA_OAUTH_URL: ${{ vars.CAMUNDA_OAUTH_URL }}
-          CAMUNDA_TASKLIST_BASE_URL: ${{ vars.CAMUNDA_TASKLIST_BASE_URL }}
-          CAMUNDA_OPERATE_BASE_URL: ${{ vars.CAMUNDA_OPERATE_BASE_URL }}
-          CAMUNDA_OPTIMIZE_BASE_URL: ${{ vars.CAMUNDA_OPTIMIZE_BASE_URL }}
-          CAMUNDA_MODELER_BASE_URL: https://modeler.cloud.camunda.io/api
-          CAMUNDA_CONSOLE_CLIENT_ID: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_ID }}
-          CAMUNDA_CONSOLE_CLIENT_SECRET: ${{ secrets.CAMUNDA_CONSOLE_CLIENT_SECRET }}
-          CAMUNDA_CONSOLE_BASE_URL: ${{ vars.CAMUNDA_CONSOLE_BASE_URL }}
-          CAMUNDA_CONSOLE_OAUTH_AUDIENCE: ${{ vars.CAMUNDA_CONSOLE_OAUTH_AUDIENCE }}
 
   local_integration_8_8:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Companion to the upcoming main PR (and to #748 which restored the push trigger). Supersedes #747.

## Context

The `selfhosted` GitHub environment will have its required reviewers removed. The Docker registry credential it carries (`DOCKER_PASSWORD`) doesn't need a human approver — fork PRs are already blocked from reading environment secrets, which is the security boundary we actually care about.

That unblocks moving the 8.7 SM jobs into the non-blocking set.

## Changes to `ci.yml`

- **Drop** `saas_integration` (8.7) and `saas_integration_8_8`. They run against shared SaaS clusters and remain in `release.yml` (which fires on merge to `stable/**`).
- **Keep** `local_integration` (8.7 SM) and `local_multitenancy_integration`, but:
  - Add `if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'`. Heavy stacks (full Camunda + Modeler) shouldn't fire on every direct push to a feature branch with no PR.
  - Keep `environment: selfhosted` so `DOCKER_PASSWORD` is still scoped to that environment. With approvers removed, no manual gate; fork PRs still cannot access the secret.

## Resulting matrix (after this + main PR land)

| Trigger | Jobs |
|---|---|
| Push to feature branch (no PR) | `unit-tests`, `local_integration_8_8` |
| PR to `stable/8.8` | `unit-tests`, `local_integration_8_8`, `local_integration` (8.7 SM), `local_multitenancy_integration` |
| Merge to `stable/8.8` | `release.yml` — full pipeline incl. SaaS + publish |

## Type of change

- [x] Improvement (CI hygiene)

## Pre-merge checklist

- [ ] Approvers removed from the `selfhosted` environment in repo settings (otherwise the SM jobs will block waiting for approval, same as before).