### PR TITLE
ci: add 8.7 SM jobs to ci.yml as PR-only non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,105 @@ jobs:
         if: always()
         run: docker compose -f docker/8.9/docker-compose.yaml down
 
+
+  # 8.7 self-managed integration tests. Uses DOCKER_PASSWORD from the
+  # `selfhosted` GitHub environment to pull images from registry.camunda.cloud.
+  # Heavy stack (full Camunda + Modeler), so PR-only — not on every push to a
+  # feature branch. Fork PRs cannot read environment secrets, so the docker
+  # login step skips them automatically.
+  local_integration:
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    environment:
+      name: selfhosted
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Workaround for https://github.com/actions/runner-images/issues/2821
+      - name: Remove mono blocking 8084 port
+        run: sudo lsof -t -i:8084 | xargs -r sudo kill -9
+
+      - name: Set up Docker
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username joshua.wulf --password-stdin registry.camunda.cloud
+
+      - name: Set up Docker Compose
+        run: |
+          docker compose -f docker/docker-compose.yaml -f docker/docker-compose-modeler.yaml up -d
+        timeout-minutes: 10
+
+      - name: Run Integration Tests
+        run: |
+          npm run test:8.7:sm
+        env:
+          ZEEBE_GRPC_ADDRESS: grpc://localhost:26500
+          ZEEBE_CLIENT_ID: zeebe
+          ZEEBE_CLIENT_SECRET: zecret
+          CAMUNDA_OAUTH_URL: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          CAMUNDA_TASKLIST_BASE_URL: http://localhost:8082
+          CAMUNDA_OPERATE_BASE_URL: http://localhost:8081
+          CAMUNDA_OPTIMIZE_BASE_URL: http://localhost:8083
+          CAMUNDA_MODELER_BASE_URL: http://localhost:8070/api
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker/docker-compose.yaml -f docker/docker-compose-modeler.yaml down
+
+  # 8.7 self-managed multi-tenancy stack. Same trigger shape as local_integration.
+  local_multitenancy_integration:
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    environment:
+      name: selfhosted
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Workaround for https://github.com/actions/runner-images/issues/2821
+      - name: Remove mono blocking 8084 port
+        run: sudo lsof -t -i:8084 | xargs -r sudo kill -9
+
+      - name: Set up Docker
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login --username joshua.wulf --password-stdin registry.camunda.cloud
+
+      - name: Set up Docker Compose
+        run: |
+          docker compose -f docker/docker-compose-multitenancy.yaml -f docker/docker-compose-modeler.yaml up -d
+        timeout-minutes: 10
+
+      - name: Run Integration Tests
+        run: |
+          npm run test:8.7:mt
+        env:
+          ZEEBE_GRPC_ADDRESS: grpc://localhost:26500
+          ZEEBE_CLIENT_ID: zeebe
+          ZEEBE_CLIENT_SECRET: zecret
+          CAMUNDA_OAUTH_URL: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
+          CAMUNDA_TASKLIST_BASE_URL: http://localhost:8082
+          CAMUNDA_OPERATE_BASE_URL: http://localhost:8081
+          CAMUNDA_OPTIMIZE_BASE_URL: http://localhost:8083
+          CAMUNDA_MODELER_BASE_URL: http://localhost:8070/api
+          # Needed for Multi-Tenancy
+          CAMUNDA_TENANT_ID: <default>
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker/docker-compose-multitenancy.yaml -f docker/docker-compose-modeler.yaml down


### PR DESCRIPTION
Companion to #749 on stable/8.8.

## Context

The `selfhosted` GitHub environment will have its required reviewers removed. The Docker registry credential it carries (`DOCKER_PASSWORD`) doesn't need a human approver — fork PRs are already blocked from reading environment secrets, which is the security boundary we actually care about.

That unblocks promoting the 8.7 SM jobs out of `release.yml`'s gated section into the regular CI feedback set.

## Changes

Add two jobs to `ci.yml`:

- `local_integration` (8.7 SM, full Camunda + Modeler stack)
- `local_multitenancy_integration` (8.7 SM multi-tenancy stack)

Both gated with:

```yaml
if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
```

PR-only (not push) because the stacks are heavy. `environment: selfhosted` is preserved so `DOCKER_PASSWORD` stays scoped to that environment; with approvers removed, no manual gate.

`release.yml` is unchanged — it still runs these on merge to `main` as part of the publish pipeline.

## Resulting matrix (with #748 + this PR landed)

| Trigger | Jobs |
|---|---|
| Push to feature branch (no PR) | `unit-tests`, `local_integration_8_8`, `local_integration_8_8_against_8_9` |
| PR to `main` | + `local_integration` (8.7 SM), `local_multitenancy_integration` |
| Merge to `main` | `release.yml` — full pipeline incl. SaaS + publish |

## Type of change

- [x] Improvement (CI hygiene)

## Pre-merge checklist

- [ ] Approvers removed from the `selfhosted` environment in repo settings (otherwise the SM jobs will block waiting for approval, same as before).