### PR TITLE
ci(stable/8.8): serialize SaaS integration jobs via concurrency groups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,14 @@ jobs:
   saas_integration:
     runs-on: ubuntu-latest
     environment: integration
+    # The 8.7 SaaS cluster is shared across workflows and refs. Approvers were
+    # previously used to serialize access; this concurrency group encodes the
+    # same constraint in CI. cancel-in-progress: false queues runs instead of
+    # cancelling them so a stable/8.8 release does not abort an in-flight main
+    # release (or vice-versa) mid-test.
+    concurrency:
+      group: saas-integration-8.7
+      cancel-in-progress: false
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6
@@ -171,6 +179,11 @@ jobs:
   saas_integration_8_8:
     runs-on: ubuntu-latest
     environment: integration-8.8
+    # See note on saas_integration above. Separate group from the 8.7 cluster
+    # so the two SaaS targets can run in parallel with each other.
+    concurrency:
+      group: saas-integration-8.8
+      cancel-in-progress: false
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6


### PR DESCRIPTION
## Context

Stable/8.8 mirror of #752 against main.

The `integration` and `integration-8.8` GitHub environments will have their required reviewers removed. That gate was doubling as a serialization mechanism for access to the shared SaaS clusters — without it, two release runs (e.g. main and stable/8.8 merging back-to-back, or a workflow_dispatch alongside a push) could hit the same cluster simultaneously and race.

## Fix

Encode the serialization in the workflow itself using **job-level concurrency groups**. The group name is repo-scoped, so the lock holds across workflows, refs, and PRs — same scope the environment lock had.

```yaml
saas_integration:
  environment: integration
  concurrency:
    group: saas-integration-8.7
    cancel-in-progress: false

saas_integration_8_8:
  environment: integration-8.8
  concurrency:
    group: saas-integration-8.8
    cancel-in-progress: false
```

Group names are identical to those in #752 — that is intentional. The lock is shared across both branches, so a stable/8.8 release queues behind an in-flight main release on the same cluster (and vice-versa).

## Design choices

- **Two separate groups.** 8.7 and 8.8 target different clusters, so they can run in parallel with each other. Each cluster sees at most one job at a time.
- **`cancel-in-progress: false`.** Queues subsequent runs instead of cancelling. A stable/8.8 release should not abort an in-flight main release mid-test.
- **Job-level, not workflow-level.** The existing workflow-level concurrency block (`camunda-8-js-sdk-release-${{ github.ref_name }}`) is unchanged — it prevents two releases of the same branch from racing each other; the new groups are about cross-workflow access to the SaaS clusters.

## Coordination

This PR should land in lockstep with #752 and the removal of required reviewers from the `integration` and `integration-8.8` environments.

## Type of change

- [x] Improvement (CI hygiene)
