### PR TITLE
[Backport stable/8.8] chore(deps): bump fast-xml-parser from 5.5.9 to 5.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,6 +1656,38 @@
 				"node": ">=10"
 			}
 		},
+<<<<<<< HEAD
+=======
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1",
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+>>>>>>> c22cd25 (chore(deps): bump fast-xml-parser from 5.5.9 to 5.7.0)
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"dev": true,
@@ -7246,9 +7278,15 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
+<<<<<<< HEAD
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
 			"integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+=======
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+			"integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+>>>>>>> c22cd25 (chore(deps): bump fast-xml-parser from 5.5.9 to 5.7.0)
 			"funding": [
 				{
 					"type": "github",
@@ -7261,9 +7299,15 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
+<<<<<<< HEAD
 			"version": "5.5.5",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.5.tgz",
 			"integrity": "sha512-NLY+V5NNbdmiEszx9n14mZBseJTC50bRq1VHsaxOmR72JDuZt+5J1Co+dC/4JPnyq+WrIHNM69r0sqf7BMb3Mg==",
+=======
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
+			"integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
+>>>>>>> c22cd25 (chore(deps): bump fast-xml-parser from 5.5.9 to 5.7.0)
 			"funding": [
 				{
 					"type": "github",
@@ -7272,9 +7316,16 @@
 			],
 			"license": "MIT",
 			"dependencies": {
+<<<<<<< HEAD
 				"fast-xml-builder": "^1.1.3",
 				"path-expression-matcher": "^1.1.3",
 				"strnum": "^2.1.2"
+=======
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.5",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+>>>>>>> c22cd25 (chore(deps): bump fast-xml-parser from 5.5.9 to 5.7.0)
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -13069,9 +13120,15 @@
 			}
 		},
 		"node_modules/path-expression-matcher": {
+<<<<<<< HEAD
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
 			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+=======
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+>>>>>>> c22cd25 (chore(deps): bump fast-xml-parser from 5.5.9 to 5.7.0)
 			"funding": [
 				{
 					"type": "github",
@@ -15595,9 +15652,15 @@
 			"license": "MIT"
 		},
 		"node_modules/strnum": {
+<<<<<<< HEAD
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
 			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+=======
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+>>>>>>> c22cd25 (chore(deps): bump fast-xml-parser from 5.5.9 to 5.7.0)
 			"funding": [
 				{
 					"type": "github",


### PR DESCRIPTION
# Description
Backport of #751 to `stable/8.8`.

relates to 