### PR TITLE
deps: pin @camunda8/orchestration-cluster-api to 8.x range

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      # Pin @camunda8/orchestration-cluster-api to the 8.x release range.
+      # The 9.x line will target Camunda 9 and is not API-compatible with
+      # this SDK's 8.x stable lines. Major bumps must be done manually as
+      # part of a `server-major` release (see release.config.js).
+      - dependency-name: "@camunda8/orchestration-cluster-api"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -27,6 +34,10 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      # See note on main: pin to 8.x on stable/8.8 as well.
+      - dependency-name: "@camunda8/orchestration-cluster-api"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "8.9.0-alpha.6",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@camunda8/orchestration-cluster-api": "^8.8.4",
+				"@camunda8/orchestration-cluster-api": ">=8.8.4 <9.0.0",
 				"@grpc/grpc-js": "^1.14.3",
 				"@grpc/proto-loader": "^0.8.0",
 				"@types/form-data": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"win-ca": "3.5.1"
 	},
 	"dependencies": {
-		"@camunda8/orchestration-cluster-api": "^8.8.4",
+		"@camunda8/orchestration-cluster-api": ">=8.8.4 <9.0.0",
 		"@grpc/grpc-js": "^1.14.3",
 		"@grpc/proto-loader": "^0.8.0",
 		"@types/form-data": "^2.2.1",


### PR DESCRIPTION
## What

- Tighten the version range for `@camunda8/orchestration-cluster-api` in `package.json` from `^8.8.4` to `>=8.8.4 <9.0.0` (semver-equivalent, but unambiguous about intent).
- Add dependabot `ignore` rules on both the `main` and `stable/8.8` npm update groups blocking `version-update:semver-major` for that package.

## Why

The 9.x line of `@camunda8/orchestration-cluster-api` will target Camunda 9 and is not API-compatible with this SDK's 8.x stable lines. We don't want dependabot opening v9 PRs against 8.x branches.

Major bumps must be performed manually as part of a `server-major` release (see `release.config.js`).

Patch and minor bumps within 8.x continue to flow as PRs as before.

## Backport

A matching PR will be opened against `stable/8.8`.

## Note for future stable lines

When promoting a new stable line (e.g. `stable/8.9`), duplicate the `ignore` block under that branch's npm group too, otherwise the new branch will silently accept v9 PRs.