### PR TITLE
deps: pin @camunda8/orchestration-cluster-api to 8.x range (stable/8.8)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "alpha"
+    ignore:
+      # Pin @camunda8/orchestration-cluster-api to the 8.x release range.
+      # The 9.x line will target Camunda 9 and is not API-compatible with
+      # this SDK's 8.x stable lines. Major bumps must be done manually as
+      # part of a `server-major` release (see release.config.js).
+      - dependency-name: "@camunda8/orchestration-cluster-api"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -15,6 +22,10 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "stable/8.8"
+    ignore:
+      # See note above: pin to 8.x on stable/8.8 as well.
+      - dependency-name: "@camunda8/orchestration-cluster-api"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "8.8.11",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@camunda8/orchestration-cluster-api": "^8.8.4",
+				"@camunda8/orchestration-cluster-api": ">=8.8.4 <9.0.0",
 				"@grpc/grpc-js": "^1.14.3",
 				"@grpc/proto-loader": "^0.8.0",
 				"@types/form-data": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
 		"win-ca": "3.5.1"
 	},
 	"dependencies": {
-		"@camunda8/orchestration-cluster-api": "^8.8.4",
+		"@camunda8/orchestration-cluster-api": ">=8.8.4 <9.0.0",
 		"@grpc/grpc-js": "^1.14.3",
 		"@grpc/proto-loader": "^0.8.0",
 		"@types/form-data": "^2.2.1",


### PR DESCRIPTION
## What

Backport of #755 to `stable/8.8`.

- Tighten the version range for `@camunda8/orchestration-cluster-api` in `package.json` from `^8.8.4` to `>=8.8.4 <9.0.0`.
- Add dependabot `ignore` rules for `version-update:semver-major` on this branch's npm update entries.

## Why

The 9.x line of `@camunda8/orchestration-cluster-api` will target Camunda 9 and is not API-compatible with this SDK's 8.x stable line. We don't want dependabot opening v9 PRs against `stable/8.8`.

## Conflict resolution

The `stable/8.8` `dependabot.yml` has a different shape from `main` (target-branches `alpha` and `stable/8.8`, no `groups` block). The `ignore` rule was added to both npm entries on this branch; the `groups` differences from `main` were preserved.

Closes the backport for #755.