### PR TITLE
fix: issue 784

### DIFF
--- a/src/zeebe/lib/ZBWorkerBase.ts
+++ b/src/zeebe/lib/ZBWorkerBase.ts
@@ -579,6 +579,8 @@ You should call only one job action method in the worker handler. This is a bug 
 					this.handleStreamEnd(id)
 					this.pollMutex = false
 				}, backoffDuration)
+			} else {
+				this.pollMutex = false
 			}
 		} else {
 			this.pollMutex = false


### PR DESCRIPTION
## Description of the change

In `ZBWorkerBase.poll()`, when `activateJobs` returns a `jobStream.error` whose message does not
  match any of the known backpressure error codes (`RESOURCE_EXHAUSTED`, `INTERNAL`, `UNAUTHENTICATED`),
  `doBackoff` is `false` and `pollMutex` is never reset. The poll interval keeps firing but every
  call exits immediately on the `pollAlreadyInProgress` guard, leaving the worker permanently stalled
  with no possibility of self-recovery.

  Added the missing `else { this.pollMutex = false }` branch so that non-backpressure errors also
  release the mutex and allow the next poll cycle to proceed.


## Type of change

- [x] Bug fix

Closes #784 