### PR TITLE
ci: add Slack notifications for release failures and community issues

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -1,0 +1,18 @@
+name: Community & Dependabot Notifications
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
+    with:
+      repo-name: camunda-8-js-sdk
+      mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,3 +374,23 @@ jobs:
         with:
           folder: docs
           branch: gh-pages
+
+  notify-release-failure:
+    needs:
+      - unit-tests
+      - local_integration
+      - local_multitenancy_integration
+      - saas_integration
+      - saas_integration_8_8
+      - local_integration_8_8
+      - local_integration_8_8_against_8_9
+      - tag-and-publish
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    permissions: {}
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-notify.yml@v1
+    with:
+      repo-name: camunda-8-js-sdk
+      workflow-name: Release
+      mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}


### PR DESCRIPTION
Adds Slack notifications to camunda-8-js-sdk via the shared `sdk-infra` reusable workflows.

## Changes

### Release failure notifications (`release.yml`)
- Added `notify-release-failure` job that fires when any pipeline stage fails
- Watches all 8 jobs: `unit-tests`, `local_integration`, `local_multitenancy_integration`, `saas_integration`, `saas_integration_8_8`, `local_integration_8_8`, `local_integration_8_8_against_8_9`, `tag-and-publish`
- Uses `camunda/sdk-infra/.github/workflows/sdk-slack-notify.yml@v1`
- Includes `@group` mention via `SLACK_MENTION_GROUP` variable

### Community & Dependabot notifications (`community-notify.yml`)
- New workflow triggered on `issues: [opened]` and `pull_request_target: [opened]`
- Uses `camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1`
- Community issues/PRs: urgent notification with `@group` mention
- Dependabot PRs: non-urgent notification (no mention)
- Maintainer activity: skipped (no notification)

## Required setup
- `SLACK_SDK_ALERTS` secret (webhook URL)
- `SLACK_MENTION_GROUP` variable (Slack group ID)