### PR TITLE
ci: add Vault-based org membership check for community notifications

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -17,3 +17,6 @@ jobs:
       author-association: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}
+      vault-addr: ${{ secrets.VAULT_ADDR }}
+      vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+      vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       repo-name: camunda-8-js-sdk
       mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+      author-association: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}


### PR DESCRIPTION
## Summary

Adds Vault integration to the community notification workflow so it can reliably detect org members — including those with private membership — and skip false-positive community alerts.

## Background

GitHub's `author_association` field returns `CONTRIBUTOR` instead of `MEMBER` for org members who have base-permission-only access (no team/direct collaborator assignment). The upstream reusable workflow in `sdk-infra` now uses the `camunda-sdk-automation` GitHub App (via Vault) to check the authenticated `/orgs/{org}/members/{username}` endpoint.

## Changes

- Pass `author-association` explicitly to the reusable workflow (defense-in-depth)
- Pass Vault secrets (`VAULT_ADDR`, `VAULT_ROLE_ID`, `VAULT_SECRET_ID`) to enable the authenticated org membership check

## Prerequisites

- [x] `camunda-sdk-automation` GitHub App installed on this repo
- [x] Repo onboarded to Vault
- [x] `sdk-infra` v1 tag updated
- [x] Verified working on C# SDK (PR camunda/orchestration-cluster-api-csharp#231)