### PR TITLE
[Backport stable/8.8] feat(modeler): add versions endpoints and deprecate milestones

### DIFF
--- a/src/__tests__/modeler/modeler.unit.spec.ts
+++ b/src/__tests__/modeler/modeler.unit.spec.ts
@@ -1,4 +1,4 @@
-import { BeforeRequestHook } from 'got'
+import type { BeforeRequestHook } from 'got'
 
 import { EnvironmentSetup, EnvironmentStorage } from '../../lib'
 import { ModelerApiClient } from '../../modeler/index'

--- a/src/__tests__/modeler/modeler.unit.spec.ts
+++ b/src/__tests__/modeler/modeler.unit.spec.ts
@@ -1,3 +1,5 @@
+import { BeforeRequestHook } from 'got'
+
 import { EnvironmentSetup, EnvironmentStorage } from '../../lib'
 import { ModelerApiClient } from '../../modeler/index'
 
@@ -31,4 +33,132 @@ test('Can get construct a client', () => {
 		},
 	})
 	expect(client).toBeTruthy()
+})
+
+/**
+ * The methods below assert the HTTP method, path, and (where applicable) request body that the
+ * client sends, without contacting a live server. We inject a `middleware` (got beforeRequest) hook
+ * that captures the outgoing request and then throws to short-circuit the network call. This guards
+ * against wrong-verb / wrong-path regressions like the milestone and collaborator bugs.
+ */
+interface CapturedRequest {
+	method?: string
+	path?: string
+	body?: unknown
+}
+
+function makeCapturingClient(captured: CapturedRequest) {
+	const middleware: BeforeRequestHook = (options) => {
+		captured.method = options.method
+		captured.path = options.url.pathname
+		captured.body = options.body
+		throw new Error('__captured__')
+	}
+	return new ModelerApiClient({
+		config: {
+			CAMUNDA_OAUTH_DISABLED: true,
+			CAMUNDA_MODELER_BASE_URL: 'http://localhost:8070/api',
+			middleware: [middleware],
+		},
+	})
+}
+
+describe('ModelerApiClient request shape', () => {
+	test('createVersion issues POST /api/v1/versions with body', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(
+			client.createVersion({ fileId: 'file-1', name: 'v1' })
+		).rejects.toThrow()
+		expect(captured.method).toBe('POST')
+		expect(captured.path).toBe('/api/v1/versions')
+		expect(JSON.parse(captured.body as string)).toEqual({
+			fileId: 'file-1',
+			name: 'v1',
+		})
+	})
+
+	test('getVersion issues GET /api/v1/versions/{versionId}', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(client.getVersion('version-1')).rejects.toThrow()
+		expect(captured.method).toBe('GET')
+		expect(captured.path).toBe('/api/v1/versions/version-1')
+	})
+
+	test('updateVersion issues PATCH /api/v1/versions/{versionId} with body', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(
+			client.updateVersion('version-1', { name: 'renamed' })
+		).rejects.toThrow()
+		expect(captured.method).toBe('PATCH')
+		expect(captured.path).toBe('/api/v1/versions/version-1')
+		expect(JSON.parse(captured.body as string)).toEqual({ name: 'renamed' })
+	})
+
+	test('deleteVersion issues DELETE /api/v1/versions/{versionId}', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(client.deleteVersion('version-1')).rejects.toThrow()
+		expect(captured.method).toBe('DELETE')
+		expect(captured.path).toBe('/api/v1/versions/version-1')
+	})
+
+	test('restoreVersion issues POST /api/v1/versions/{versionId}/restore with body', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(
+			client.restoreVersion('version-1', { version: 3 })
+		).rejects.toThrow()
+		expect(captured.method).toBe('POST')
+		expect(captured.path).toBe('/api/v1/versions/version-1/restore')
+		expect(JSON.parse(captured.body as string)).toEqual({ version: 3 })
+	})
+
+	test('compareVersions issues GET /api/v1/versions/compare/{a}...{b}', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(client.compareVersions('a', 'b')).rejects.toThrow()
+		expect(captured.method).toBe('GET')
+		expect(captured.path).toBe('/api/v1/versions/compare/a...b')
+	})
+
+	test('searchVersions issues POST /api/v1/versions/search with body', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(
+			client.searchVersions({ filter: { fileId: 'file-1' } })
+		).rejects.toThrow()
+		expect(captured.method).toBe('POST')
+		expect(captured.path).toBe('/api/v1/versions/search')
+		expect(JSON.parse(captured.body as string)).toEqual({
+			filter: { fileId: 'file-1' },
+		})
+	})
+
+	// Regression guard for the fixed GET -> DELETE bug on the deprecated milestone endpoint.
+	test('deleteMilestone issues DELETE /api/v1/milestones/{milestoneId}', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(client.deleteMilestone('milestone-1')).rejects.toThrow()
+		expect(captured.method).toBe('DELETE')
+		expect(captured.path).toBe('/api/v1/milestones/milestone-1')
+	})
+
+	// Regression guard for the fixed malformed collaborator path.
+	test('deleteCollaborator issues DELETE /api/v1/projects/{projectId}/collaborators/{email}', async () => {
+		const captured: CapturedRequest = {}
+		const client = makeCapturingClient(captured)
+		await expect(
+			client.deleteCollaborator({
+				projectId: 'project-1',
+				email: 'user@example.com',
+			})
+		).rejects.toThrow()
+		expect(captured.method).toBe('DELETE')
+		expect(captured.path).toBe(
+			'/api/v1/projects/project-1/collaborators/user@example.com'
+		)
+	})
 })

--- a/src/modeler/lib/ModelerAPIClient.ts
+++ b/src/modeler/lib/ModelerAPIClient.ts
@@ -149,7 +149,8 @@ export class ModelerApiClient {
 			.delete(`projects/${projectId}/collaborators/${email}`, {
 				headers,
 			})
-			.then(this.decodeResponseOrThrow) as Promise<null>
+			.then(this.decodeResponseOrThrow)
+			.then(() => null)
 	}
 
 	/**
@@ -447,7 +448,8 @@ export class ModelerApiClient {
 			.delete(`milestones/${milestoneId}`, {
 				headers,
 			})
-			.then(this.decodeResponseOrThrow) as Promise<null>
+			.then(this.decodeResponseOrThrow)
+			.then(() => null)
 	}
 
 	/**
@@ -588,7 +590,8 @@ export class ModelerApiClient {
 			.delete(`versions/${versionId}`, {
 				headers,
 			})
-			.then(this.decodeResponseOrThrow) as Promise<null>
+			.then(this.decodeResponseOrThrow)
+			.then(() => null)
 	}
 
 	/**

--- a/src/modeler/lib/ModelerAPIClient.ts
+++ b/src/modeler/lib/ModelerAPIClient.ts
@@ -99,7 +99,8 @@ export class ModelerApiClient {
 	 */
 	async addCollaborator(req: Dto.CreateCollaboratorDto): Promise<null> {
 		const headers = await this.getHeaders()
-		return got
+		const rest = await this.rest
+		return rest
 			.put(`collaborators`, {
 				headers,
 				body: JSON.stringify(req),
@@ -119,7 +120,8 @@ export class ModelerApiClient {
 		req: Dto.PubSearchDtoProjectCollaboratorDto
 	): Promise<Dto.PubSearchResultDtoProjectCollaboratorDto> {
 		const headers = await this.getHeaders()
-		return got
+		const rest = await this.rest
+		return rest
 			.post(`collaborators/search`, {
 				headers,
 				body: JSON.stringify(req),
@@ -144,7 +146,7 @@ export class ModelerApiClient {
 		const headers = await this.getHeaders()
 		const rest = await this.rest
 		return rest
-			.delete(`project/${projectId}collaborators/${email}`, {
+			.delete(`projects/${projectId}/collaborators/${email}`, {
 				headers,
 			})
 			.then(this.decodeResponseOrThrow) as Promise<null>
@@ -395,7 +397,10 @@ export class ModelerApiClient {
 	}
 
 	/**
+	 * Creates a milestone (a named snapshot of a file).
 	 *
+	 * @deprecated Milestones were renamed to versions in Web Modeler 8.9. The `milestones` endpoints are
+	 * only available in Web Modeler 8.8 and earlier. For Web Modeler 8.9 and later, use {@link createVersion}.
 	 * @throws {RESTError}
 	 */
 	async createMilestone(
@@ -414,7 +419,8 @@ export class ModelerApiClient {
 	}
 
 	/**
-	 *
+	 * @deprecated Milestones were renamed to versions in Web Modeler 8.9. The `milestones` endpoints are
+	 * only available in Web Modeler 8.8 and earlier. For Web Modeler 8.9 and later, use {@link getVersion}.
 	 * @throws {RESTError}
 	 */
 	async getMilestone(milestoneId: string): Promise<Dto.MilestoneDto> {
@@ -429,18 +435,26 @@ export class ModelerApiClient {
 
 	/**
 	 * Deletion of resources is recursive and cannot be undone.
+	 *
+	 * @deprecated Milestones were renamed to versions in Web Modeler 8.9. The `milestones` endpoints are
+	 * only available in Web Modeler 8.8 and earlier. For Web Modeler 8.9 and later, use {@link deleteVersion}.
 	 * @throws {RESTError}
 	 */
 	async deleteMilestone(milestoneId: string) {
 		const headers = await this.getHeaders()
 		const rest = await this.rest
-		return rest(`milestones/${milestoneId}`, {
-			headers,
-		}).then(this.decodeResponseOrThrow)
+		return rest
+			.delete(`milestones/${milestoneId}`, {
+				headers,
+			})
+			.then(this.decodeResponseOrThrow)
 	}
 
 	/**
 	 * Returns a link to a visual comparison between two milestones where the milestone referenced by milestone1Id acts as a baseline to compare the milestone referenced by milestone2Id against.
+	 *
+	 * @deprecated Milestones were renamed to versions in Web Modeler 8.9. The `milestones` endpoints are
+	 * only available in Web Modeler 8.8 and earlier. For Web Modeler 8.9 and later, use {@link compareVersions}.
 	 * @throws {RESTError}
 	 */
 	async getMilestoneComparison(
@@ -476,6 +490,9 @@ export class ModelerApiClient {
 	 * page specifies the page number to return.
 	 *
 	 * size specifies the number of items per page. The default value is 10.
+	 *
+	 * @deprecated Milestones were renamed to versions in Web Modeler 8.9. The `milestones` endpoints are
+	 * only available in Web Modeler 8.8 and earlier. For Web Modeler 8.9 and later, use {@link searchVersions}.
 	 * @throws {RESTError}
 	 */
 	async searchMilestones(
@@ -491,6 +508,171 @@ export class ModelerApiClient {
 			.then((res) =>
 				JSON.parse(this.decodeResponseOrThrow(res))
 			) as Promise<Dto.PubSearchResultDtoMilestoneMetadataDto>
+	}
+
+	/**
+	 * Creates a version (a named snapshot of a file).
+	 *
+	 * Versions are the successor to milestones (renamed in Web Modeler 8.9). Use this method for
+	 * Web Modeler 8.9 and later; for Web Modeler 8.8 and earlier, use {@link createMilestone}.
+	 * @throws {RESTError}
+	 */
+	async createVersion(
+		req: Dto.CreateVersionDto
+	): Promise<Dto.VersionMetadataDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.post(`versions`, {
+				headers,
+				body: JSON.stringify(req),
+			})
+			.then((res) =>
+				JSON.parse(this.decodeResponseOrThrow(res))
+			) as Promise<Dto.VersionMetadataDto>
+	}
+
+	/**
+	 * Retrieves a version.
+	 *
+	 * Versions are the successor to milestones (renamed in Web Modeler 8.9). Use this method for
+	 * Web Modeler 8.9 and later; for Web Modeler 8.8 and earlier, use {@link getMilestone}.
+	 * @throws {RESTError}
+	 */
+	async getVersion(versionId: string): Promise<Dto.VersionDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest(`versions/${versionId}`, {
+			headers,
+		}).then((res) =>
+			JSON.parse(this.decodeResponseOrThrow(res))
+		) as Promise<Dto.VersionDto>
+	}
+
+	/**
+	 * Updates the name, description, or organization visibility of a version.
+	 *
+	 * This capability has no milestone equivalent; it was added alongside versions in Web Modeler 8.9.
+	 * @throws {RESTError}
+	 */
+	async updateVersion(
+		versionId: string,
+		update: Dto.UpdateVersionDto
+	): Promise<Dto.VersionMetadataDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.patch(`versions/${versionId}`, {
+				headers,
+				body: JSON.stringify(update),
+			})
+			.then((res) =>
+				JSON.parse(this.decodeResponseOrThrow(res))
+			) as Promise<Dto.VersionMetadataDto>
+	}
+
+	/**
+	 * Deletion of resources is recursive and cannot be undone.
+	 *
+	 * Versions are the successor to milestones (renamed in Web Modeler 8.9). Use this method for
+	 * Web Modeler 8.9 and later; for Web Modeler 8.8 and earlier, use {@link deleteMilestone}.
+	 * @throws {RESTError}
+	 */
+	async deleteVersion(versionId: string) {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.delete(`versions/${versionId}`, {
+				headers,
+			})
+			.then(this.decodeResponseOrThrow)
+	}
+
+	/**
+	 * Restores a file to the state captured by the given version.
+	 *
+	 * This capability has no milestone equivalent; it was added alongside versions in Web Modeler 8.9.
+	 * @throws {RESTError}
+	 */
+	async restoreVersion(
+		versionId: string,
+		req: Dto.RestoreVersionDto
+	): Promise<Dto.VersionMetadataDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.post(`versions/${versionId}/restore`, {
+				headers,
+				body: JSON.stringify(req),
+			})
+			.then((res) =>
+				JSON.parse(this.decodeResponseOrThrow(res))
+			) as Promise<Dto.VersionMetadataDto>
+	}
+
+	/**
+	 * Returns a link to a visual comparison between two versions where the version referenced by version1Id acts as a baseline to compare the version referenced by version2Id against.
+	 *
+	 * Versions are the successor to milestones (renamed in Web Modeler 8.9). Use this method for
+	 * Web Modeler 8.9 and later; for Web Modeler 8.8 and earlier, use {@link getMilestoneComparison}.
+	 *
+	 * Note: unlike the milestone comparison (which returned the link as a plain string), this returns a
+	 * {@link Dto.VersionComparisonDto} object with a `url` property.
+	 * @throws {RESTError}
+	 */
+	async compareVersions(
+		version1Id: string,
+		version2Id: string
+	): Promise<Dto.VersionComparisonDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest(`versions/compare/${version1Id}...${version2Id}`, {
+			headers,
+		}).then((res) =>
+			JSON.parse(this.decodeResponseOrThrow(res))
+		) as Promise<Dto.VersionComparisonDto>
+	}
+
+	/**
+	 * Searches for versions.
+	 *
+	 * filter specifies which fields should match. Only items that match the given fields will be returned.
+	 *
+	 * Note: Date fields need to be specified in a format compatible with java.time.ZonedDateTime; for example 2023-09-20T11:31:20.206801604Z.
+	 *
+	 * You can use suffixes to match date ranges:
+	 *
+	 * Modifier	Description
+	 * ||/y	Within a year
+	 * ||/M	Within a month
+	 * ||/w	Within a week
+	 * ||/d	Within a day
+	 * ||/h	Within an hour
+	 * ||/m	Within a minute
+	 * ||/s	Within a second
+	 * sort specifies by which fields and direction (ASC/DESC) the result should be sorted.
+	 *
+	 * page specifies the page number to return.
+	 *
+	 * size specifies the number of items per page. The default value is 10.
+	 *
+	 * Versions are the successor to milestones (renamed in Web Modeler 8.9). Use this method for
+	 * Web Modeler 8.9 and later; for Web Modeler 8.8 and earlier, use {@link searchMilestones}.
+	 * @throws {RESTError}
+	 */
+	async searchVersions(
+		req: Dto.PubSearchDtoVersionMetadataDto
+	): Promise<Dto.PubSearchResultDtoVersionMetadataDto> {
+		const headers = await this.getHeaders()
+		const rest = await this.rest
+		return rest
+			.post(`versions/search`, {
+				headers,
+				body: JSON.stringify(req),
+			})
+			.then((res) =>
+				JSON.parse(this.decodeResponseOrThrow(res))
+			) as Promise<Dto.PubSearchResultDtoVersionMetadataDto>
 	}
 
 	/**

--- a/src/modeler/lib/ModelerAPIClient.ts
+++ b/src/modeler/lib/ModelerAPIClient.ts
@@ -105,7 +105,8 @@ export class ModelerApiClient {
 				headers,
 				body: JSON.stringify(req),
 			})
-			.then(this.decodeResponseOrThrow) as Promise<null>
+			.then(this.decodeResponseOrThrow)
+			.then(() => null)
 	}
 
 	/**
@@ -224,7 +225,8 @@ export class ModelerApiClient {
 			.delete(`files/${fileId}`, {
 				headers,
 			})
-			.then(this.decodeResponseOrThrow) as Promise<null>
+			.then(this.decodeResponseOrThrow)
+			.then(() => null)
 	}
 
 	/**
@@ -352,7 +354,8 @@ export class ModelerApiClient {
 			.delete(`folders/${folderId}`, {
 				headers,
 			})
-			.then(this.decodeResponseOrThrow) as Promise<null>
+			.then(this.decodeResponseOrThrow)
+			.then(() => null)
 	}
 
 	/**

--- a/src/modeler/lib/ModelerAPIClient.ts
+++ b/src/modeler/lib/ModelerAPIClient.ts
@@ -440,14 +440,14 @@ export class ModelerApiClient {
 	 * only available in Web Modeler 8.8 and earlier. For Web Modeler 8.9 and later, use {@link deleteVersion}.
 	 * @throws {RESTError}
 	 */
-	async deleteMilestone(milestoneId: string) {
+	async deleteMilestone(milestoneId: string): Promise<null> {
 		const headers = await this.getHeaders()
 		const rest = await this.rest
 		return rest
 			.delete(`milestones/${milestoneId}`, {
 				headers,
 			})
-			.then(this.decodeResponseOrThrow)
+			.then(this.decodeResponseOrThrow) as Promise<null>
 	}
 
 	/**
@@ -581,14 +581,14 @@ export class ModelerApiClient {
 	 * Web Modeler 8.9 and later; for Web Modeler 8.8 and earlier, use {@link deleteMilestone}.
 	 * @throws {RESTError}
 	 */
-	async deleteVersion(versionId: string) {
+	async deleteVersion(versionId: string): Promise<null> {
 		const headers = await this.getHeaders()
 		const rest = await this.rest
 		return rest
 			.delete(`versions/${versionId}`, {
 				headers,
 			})
-			.then(this.decodeResponseOrThrow)
+			.then(this.decodeResponseOrThrow) as Promise<null>
 	}
 
 	/**

--- a/src/modeler/lib/ModelerAPIClient.ts
+++ b/src/modeler/lib/ModelerAPIClient.ts
@@ -511,7 +511,10 @@ export class ModelerApiClient {
 	}
 
 	/**
-	 * Creates a version (a named snapshot of a file).
+	 * Creates a version (a snapshot of a file).
+	 *
+	 * `name` is optional: if omitted, Web Modeler assigns a name automatically. Provide `name` to
+	 * create a named version.
 	 *
 	 * Versions are the successor to milestones (renamed in Web Modeler 8.9). Use this method for
 	 * Web Modeler 8.9 and later; for Web Modeler 8.8 and earlier, use {@link createMilestone}.

--- a/src/modeler/lib/ModelerDto.ts
+++ b/src/modeler/lib/ModelerDto.ts
@@ -144,6 +144,10 @@ export interface UpdateFolderDto {
 	parentId: string
 }
 
+/**
+ * @deprecated Milestones were renamed to versions in Web Modeler 8.9. Use {@link CreateVersionDto} instead.
+ * This type targets the `milestones` endpoints, which are only available in Web Modeler 8.8 and earlier.
+ */
 export interface CreateMilestoneDto {
 	/** maxLength: 255 minLength: 1 */
 	name: string
@@ -151,6 +155,10 @@ export interface CreateMilestoneDto {
 	fileId: string
 }
 
+/**
+ * @deprecated Milestones were renamed to versions in Web Modeler 8.9. Use {@link VersionMetadataDto} instead.
+ * This type targets the `milestones` endpoints, which are only available in Web Modeler 8.8 and earlier.
+ */
 export interface MilestoneMetadataDto {
 	id: string
 	name: string
@@ -161,11 +169,19 @@ export interface MilestoneMetadataDto {
 	updatedBy: UserDto
 }
 
+/**
+ * @deprecated Milestones were renamed to versions in Web Modeler 8.9. Use {@link VersionDto} instead.
+ * This type targets the `milestones` endpoints, which are only available in Web Modeler 8.8 and earlier.
+ */
 export interface MilestoneDto {
 	metadata: MilestoneMetadataDto
 	content: string
 }
 
+/**
+ * @deprecated Milestones were renamed to versions in Web Modeler 8.9. Use {@link PubSearchDtoVersionMetadataDto} instead.
+ * This type targets the `milestones` endpoints, which are only available in Web Modeler 8.8 and earlier.
+ */
 export interface PubSearchDtoMilestoneMetadataDto {
 	filter: Partial<MilestoneMetadataDto>
 	sort?: SortDto[]
@@ -175,8 +191,75 @@ export interface PubSearchDtoMilestoneMetadataDto {
 	size?: number
 }
 
+/**
+ * @deprecated Milestones were renamed to versions in Web Modeler 8.9. Use {@link PubSearchResultDtoVersionMetadataDto} instead.
+ * This type targets the `milestones` endpoints, which are only available in Web Modeler 8.8 and earlier.
+ */
 export interface PubSearchResultDtoMilestoneMetadataDto {
 	items: MilestoneMetadataDto[]
+	total: number
+}
+
+/**
+ * Versions are the successor to milestones (renamed in Web Modeler 8.9).
+ * Use the `versions` endpoints in Web Modeler 8.9 and later.
+ */
+export interface CreateVersionDto {
+	/** maxLength: 255 minLength: 1 */
+	name?: string
+	description?: string
+	/** maxLength: 255 minLength: 1 */
+	fileId: string
+	organizationPublic?: boolean
+}
+
+export interface VersionMetadataDto {
+	id: string
+	name: string
+	description?: string
+	fileId: string
+	created: string
+	createdBy: UserDto
+	updated: string
+	updatedBy: UserDto
+	organizationPublic?: boolean
+}
+
+export interface VersionDto {
+	metadata: VersionMetadataDto
+	content: string
+}
+
+export interface UpdateVersionDto {
+	/** maxLength: 255 minLength: 1 */
+	name?: string
+	description?: string
+	organizationPublic?: boolean
+}
+
+export interface RestoreVersionDto {
+	/** The version number to restore. */
+	version: number
+}
+
+/**
+ * The result of comparing two versions. `url` is a link to a visual comparison in Web Modeler.
+ */
+export interface VersionComparisonDto {
+	url: string
+}
+
+export interface PubSearchDtoVersionMetadataDto {
+	filter: Partial<VersionMetadataDto>
+	sort?: SortDto[]
+	/** minimum: 0 */
+	page?: number
+	/** maximum: 50 minimum: 0 */
+	size?: number
+}
+
+export interface PubSearchResultDtoVersionMetadataDto {
+	items: VersionMetadataDto[]
 	total: number
 }
 

--- a/src/modeler/lib/ModelerDto.ts
+++ b/src/modeler/lib/ModelerDto.ts
@@ -205,7 +205,10 @@ export interface PubSearchResultDtoMilestoneMetadataDto {
  * Use the `versions` endpoints in Web Modeler 8.9 and later.
  */
 export interface CreateVersionDto {
-	/** maxLength: 255 minLength: 1 */
+	/**
+	 * Optional. If omitted, Web Modeler assigns a name automatically.
+	 * maxLength: 255 minLength: 1
+	 */
 	name?: string
 	description?: string
 	/** maxLength: 255 minLength: 1 */


### PR DESCRIPTION
# Description
Backport of #813 to `stable/8.8`.

relates to #812